### PR TITLE
Time provider moved from state manager to util package

### DIFF
--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/metrics"
 	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/util/time_util"
 )
 
 type blockTime struct {
@@ -22,13 +23,13 @@ type blockCache struct {
 	maxCacheSize int
 	wal          BlockWAL
 	times        []*blockTime
-	timeProvider TimeProvider
+	timeProvider time_util.TimeProvider
 	metrics      *metrics.ChainStateManagerMetrics
 }
 
 var _ BlockCache = &blockCache{}
 
-func NewBlockCache(tp TimeProvider, maxCacheSize int, wal BlockWAL, metrics *metrics.ChainStateManagerMetrics, log *logger.Logger) (BlockCache, error) {
+func NewBlockCache(tp time_util.TimeProvider, maxCacheSize int, wal BlockWAL, metrics *metrics.ChainStateManagerMetrics, log *logger.Logger) (BlockCache, error) {
 	return &blockCache{
 		log:          log.Named("BC"),
 		blocks:       shrinkingmap.New[BlockKey, state.Block](),

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_rapid_no_wal_test.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_rapid_no_wal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/util"
+	"github.com/iotaledger/wasp/packages/util/time_util"
 )
 
 type blockCacheNoWALTestSM struct { // State machine for block cache no WAL property based Rapid tests
@@ -39,7 +40,7 @@ func (bcnwtsmT *blockCacheNoWALTestSM) initStateMachine(t *rapid.T, bcms int, wa
 	bcnwtsmT.lastBlockCommitment = origin.L1Commitment(0, nil, 0)
 	bcnwtsmT.log = testlogger.NewLogger(t)
 	bcnwtsmT.blockCacheMaxSize = bcms
-	bcnwtsmT.bc, err = NewBlockCache(NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, wal, mockStateManagerMetrics(), bcnwtsmT.log)
+	bcnwtsmT.bc, err = NewBlockCache(time_util.NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, wal, mockStateManagerMetrics(), bcnwtsmT.log)
 	require.NoError(t, err)
 	bcnwtsmT.blockTimes = make([]*blockTime, 0)
 	bcnwtsmT.blocks = make(map[BlockKey]state.Block)
@@ -112,7 +113,7 @@ func (bcnwtsmT *blockCacheNoWALTestSM) tstGetBlockFromCache(t *rapid.T, blockKey
 
 func (bcnwtsmT *blockCacheNoWALTestSM) Restart(t *rapid.T) {
 	var err error
-	bcnwtsmT.bc, err = NewBlockCache(NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, bcnwtsmT.bc.(*blockCache).wal, mockStateManagerMetrics(), bcnwtsmT.log)
+	bcnwtsmT.bc, err = NewBlockCache(time_util.NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, bcnwtsmT.bc.(*blockCache).wal, mockStateManagerMetrics(), bcnwtsmT.log)
 	require.NoError(t, err)
 	bcnwtsmT.blocksInCache = make([]BlockKey, 0)
 	bcnwtsmT.blockTimes = make([]*blockTime, 0)

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_test.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/util"
+	"github.com/iotaledger/wasp/packages/util/time_util"
 )
 
 func TestBlockCacheSimple(t *testing.T) {
@@ -21,7 +22,7 @@ func TestBlockCacheSimple(t *testing.T) {
 
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(4, 1)
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), mockStateManagerMetrics(), log)
+	blockCache, err := NewBlockCache(time_util.NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0])
 	blockCache.AddBlock(blocks[1])
@@ -38,7 +39,7 @@ func TestBlockCacheCleaning(t *testing.T) {
 
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(6, 2)
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), mockStateManagerMetrics(), log)
+	blockCache, err := NewBlockCache(time_util.NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 
 	beforeTime := time.Now()
@@ -85,7 +86,7 @@ func TestBlockCacheSameBlockCleaning(t *testing.T) {
 
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(3, 2)
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), mockStateManagerMetrics(), log)
+	blockCache, err := NewBlockCache(time_util.NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0])
 	blockCache.AddBlock(blocks[1])
@@ -118,7 +119,7 @@ func TestBlockCacheWAL(t *testing.T) {
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(3, 2)
 	wal := NewMockedTestBlockWAL()
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, wal, mockStateManagerMetrics(), log)
+	blockCache, err := NewBlockCache(time_util.NewDefaultTimeProvider(), 100, wal, mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0])
 	blockCache.AddBlock(blocks[1])
@@ -143,7 +144,7 @@ func TestBlockCacheCleanUp(t *testing.T) {
 	blocks := factory.GetBlocks(16, 2)
 	now := time.Now()
 	wal := NewEmptyTestBlockWAL()
-	tp := NewArtifficialTimeProvider(now)
+	tp := time_util.NewArtifficialTimeProvider(now)
 	blockCache, err := NewBlockCache(tp, 5, wal, mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 	setNowAddBlockFun := func(d time.Duration, b state.Block) {
@@ -219,7 +220,7 @@ func TestBlockCacheFull(t *testing.T) {
 	blocks := factory.GetBlocks(5, 2)
 	now := time.Now()
 	wal := NewMockedTestBlockWAL()
-	tp := NewArtifficialTimeProvider(now)
+	tp := time_util.NewArtifficialTimeProvider(now)
 	blockCache, err := NewBlockCache(tp, 100, wal, mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0]) // Will be dropped from cache AND WAL

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_test.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_test.go
@@ -144,7 +144,7 @@ func TestBlockCacheCleanUp(t *testing.T) {
 	blocks := factory.GetBlocks(16, 2)
 	now := time.Now()
 	wal := NewEmptyTestBlockWAL()
-	tp := time_util.NewArtifficialTimeProvider(now)
+	tp := time_util.NewArtificialTimeProvider(now)
 	blockCache, err := NewBlockCache(tp, 5, wal, mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 	setNowAddBlockFun := func(d time.Duration, b state.Block) {
@@ -220,7 +220,7 @@ func TestBlockCacheFull(t *testing.T) {
 	blocks := factory.GetBlocks(5, 2)
 	now := time.Now()
 	wal := NewMockedTestBlockWAL()
-	tp := time_util.NewArtifficialTimeProvider(now)
+	tp := time_util.NewArtificialTimeProvider(now)
 	blockCache, err := NewBlockCache(tp, 100, wal, mockStateManagerMetrics(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0]) // Will be dropped from cache AND WAL

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/interface.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/interface.go
@@ -19,9 +19,3 @@ type BlockWAL interface {
 	Read(state.BlockHash) (state.Block, error)
 	ReadAllByStateIndex(cb func(stateIndex uint32, block state.Block) bool) error
 }
-
-type TimeProvider interface {
-	SetNow(time.Time)
-	GetNow() time.Time
-	After(time.Duration) <-chan time.Time
-}

--- a/packages/chain/statemanager/sm_gpa/state_manager_gpa_test.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_gpa_test.go
@@ -15,9 +15,10 @@ import (
 	"github.com/iotaledger/wasp/packages/gpa"
 	"github.com/iotaledger/wasp/packages/origin"
 	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/util/time_util"
 )
 
-var newEmptySnapshotManagerFun = func(_, _ state.Store, _ sm_gpa_utils.TimeProvider, _ *logger.Logger) sm_snapshots.SnapshotManager {
+var newEmptySnapshotManagerFun = func(_, _ state.Store, _ time_util.TimeProvider, _ *logger.Logger) sm_snapshots.SnapshotManager {
 	return sm_snapshots.NewEmptySnapshotManager()
 }
 
@@ -320,7 +321,7 @@ func TestMempoolSnapshotInTheMiddle(t *testing.T) {
 
 	nodeIDs := gpa.MakeTestNodeIDs(3)
 	newMockedTestBlockWALFun := func(gpa.NodeID) sm_gpa_utils.TestBlockWAL { return sm_gpa_utils.NewMockedTestBlockWAL() }
-	newMockedSnapshotManagerFun := func(nodeID gpa.NodeID, origStore, nodeStore state.Store, timeProvider sm_gpa_utils.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager {
+	newMockedSnapshotManagerFun := func(nodeID gpa.NodeID, origStore, nodeStore state.Store, timeProvider time_util.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager {
 		var snapshotToLoad sm_snapshots.SnapshotInfo
 		if nodeID.Equals(nodeIDs[0]) {
 			snapshotToLoad = nil
@@ -485,7 +486,7 @@ func TestSnapshots(t *testing.T) {
 
 	nodeIDs := gpa.MakeTestNodeIDs(1)
 	nodeID := nodeIDs[0]
-	newMockedSnapshotManagerFun := func(origStore, nodeStore state.Store, tp sm_gpa_utils.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager {
+	newMockedSnapshotManagerFun := func(origStore, nodeStore state.Store, tp time_util.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager {
 		return sm_snapshots.NewMockedSnapshotManager(t, snapshotCreatePeriod, snapshotDelayPeriod, origStore, nodeStore, nil, snapshotCreateTime, tp, log)
 	}
 	env := newTestEnv(t, nodeIDs, sm_gpa_utils.NewEmptyTestBlockWAL, newMockedSnapshotManagerFun)

--- a/packages/chain/statemanager/sm_gpa/state_manager_parameters.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_parameters.go
@@ -6,7 +6,7 @@ package sm_gpa
 import (
 	"time"
 
-	"github.com/iotaledger/wasp/packages/chain/statemanager/sm_gpa/sm_gpa_utils"
+	"github.com/iotaledger/wasp/packages/util/time_util"
 )
 
 type StateManagerParameters struct {
@@ -31,15 +31,15 @@ type StateManagerParameters struct {
 	// On single store pruning attempt at most this number of states will be deleted
 	PruningMaxStatesToDelete int
 
-	TimeProvider sm_gpa_utils.TimeProvider
+	TimeProvider time_util.TimeProvider
 }
 
-func NewStateManagerParameters(tpOpt ...sm_gpa_utils.TimeProvider) StateManagerParameters {
-	var tp sm_gpa_utils.TimeProvider
+func NewStateManagerParameters(tpOpt ...time_util.TimeProvider) StateManagerParameters {
+	var tp time_util.TimeProvider
 	if len(tpOpt) > 0 {
 		tp = tpOpt[0]
 	} else {
-		tp = sm_gpa_utils.NewDefaultTimeProvider()
+		tp = time_util.NewDefaultTimeProvider()
 	}
 	return StateManagerParameters{
 		BlockCacheMaxSize:                 1000,

--- a/packages/chain/statemanager/sm_gpa/test_env.go
+++ b/packages/chain/statemanager/sm_gpa/test_env.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/util"
+	"github.com/iotaledger/wasp/packages/util/time_util"
 )
 
 type testEnv struct {
@@ -41,7 +42,7 @@ func newTestEnv(
 	t *testing.T,
 	nodeIDs []gpa.NodeID,
 	createWALFun func() sm_gpa_utils.TestBlockWAL,
-	createSnapMFun func(origStore, nodeStore state.Store, tp sm_gpa_utils.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager,
+	createSnapMFun func(origStore, nodeStore state.Store, tp time_util.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager,
 	parametersOpt ...StateManagerParameters,
 ) *testEnv {
 	result := newTestEnvNoNodes(t, parametersOpt...)
@@ -80,7 +81,7 @@ func newTestEnvNoNodes(
 
 	bf = sm_gpa_utils.NewBlockFactory(t, chainInitParameters)
 	log := testlogger.NewLogger(t)
-	parameters.TimeProvider = sm_gpa_utils.NewArtifficialTimeProvider()
+	parameters.TimeProvider = time_util.NewArtifficialTimeProvider()
 	return &testEnv{
 		t:          t,
 		bf:         bf,
@@ -92,12 +93,12 @@ func newTestEnvNoNodes(
 func (teT *testEnv) addNodes(
 	nodeIDs []gpa.NodeID,
 	createWALFun func() sm_gpa_utils.TestBlockWAL,
-	createSnapMFun func(origStore, nodeStore state.Store, tp sm_gpa_utils.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager,
+	createSnapMFun func(origStore, nodeStore state.Store, tp time_util.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager,
 ) {
 	createWALVariedFun := func(gpa.NodeID) sm_gpa_utils.TestBlockWAL {
 		return createWALFun()
 	}
-	createSnapMVariedFun := func(nodeID gpa.NodeID, origStore, nodeStore state.Store, tp sm_gpa_utils.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager {
+	createSnapMVariedFun := func(nodeID gpa.NodeID, origStore, nodeStore state.Store, tp time_util.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager {
 		return createSnapMFun(origStore, nodeStore, tp, log)
 	}
 	teT.addVariedNodes(nodeIDs, createWALVariedFun, createSnapMVariedFun)
@@ -106,7 +107,7 @@ func (teT *testEnv) addNodes(
 func (teT *testEnv) addVariedNodes(
 	nodeIDs []gpa.NodeID,
 	createWALFun func(gpa.NodeID) sm_gpa_utils.TestBlockWAL,
-	createSnapMFun func(nodeID gpa.NodeID, origStore, nodeStore state.Store, tp sm_gpa_utils.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager,
+	createSnapMFun func(nodeID gpa.NodeID, origStore, nodeStore state.Store, tp time_util.TimeProvider, log *logger.Logger) sm_snapshots.SnapshotManager,
 ) {
 	sms := make(map[gpa.NodeID]gpa.GPA)
 	stores := make(map[gpa.NodeID]state.Store)

--- a/packages/chain/statemanager/sm_gpa/test_env.go
+++ b/packages/chain/statemanager/sm_gpa/test_env.go
@@ -81,7 +81,7 @@ func newTestEnvNoNodes(
 
 	bf = sm_gpa_utils.NewBlockFactory(t, chainInitParameters)
 	log := testlogger.NewLogger(t)
-	parameters.TimeProvider = time_util.NewArtifficialTimeProvider()
+	parameters.TimeProvider = time_util.NewArtificialTimeProvider()
 	return &testEnv{
 		t:          t,
 		bf:         bf,

--- a/packages/chain/statemanager/sm_snapshots/snapshot_manager_mocked.go
+++ b/packages/chain/statemanager/sm_snapshots/snapshot_manager_mocked.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/iotaledger/wasp/packages/chain/statemanager/sm_gpa/sm_gpa_utils"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/util"
+	"github.com/iotaledger/wasp/packages/util/time_util"
 )
 
 type MockedSnapshotManager struct {
@@ -27,7 +27,7 @@ type MockedSnapshotManager struct {
 	readySnapshotsMutex sync.Mutex
 
 	snapshotCommitTime time.Duration
-	timeProvider       sm_gpa_utils.TimeProvider
+	timeProvider       time_util.TimeProvider
 
 	origStore      state.Store
 	nodeStore      state.Store
@@ -51,7 +51,7 @@ func NewMockedSnapshotManager(
 	nodeStore state.Store,
 	snapshotToLoad SnapshotInfo,
 	snapshotCommitTime time.Duration,
-	timeProvider sm_gpa_utils.TimeProvider,
+	timeProvider time_util.TimeProvider,
 	log *logger.Logger,
 ) *MockedSnapshotManager {
 	result := &MockedSnapshotManager{

--- a/packages/util/time_util/interface.go
+++ b/packages/util/time_util/interface.go
@@ -1,0 +1,11 @@
+package time_util
+
+import (
+	"time"
+)
+
+type TimeProvider interface {
+	SetNow(time.Time)
+	GetNow() time.Time
+	After(time.Duration) <-chan time.Time
+}

--- a/packages/util/time_util/time_provider_artifficial.go
+++ b/packages/util/time_util/time_provider_artifficial.go
@@ -1,4 +1,4 @@
-package sm_gpa_utils
+package time_util
 
 import (
 	"sync"

--- a/packages/util/time_util/time_provider_artifficial.go
+++ b/packages/util/time_util/time_provider_artifficial.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-type artifficialTimeProvider struct {
+type artificialTimeProvider struct {
 	now    time.Time
 	timers []*timer
 	mutex  sync.Mutex
@@ -16,23 +16,23 @@ type timer struct {
 	channel chan time.Time
 }
 
-var _ TimeProvider = &artifficialTimeProvider{}
+var _ TimeProvider = &artificialTimeProvider{}
 
-func NewArtifficialTimeProvider(nowOpt ...time.Time) TimeProvider {
+func NewArtificialTimeProvider(nowOpt ...time.Time) TimeProvider {
 	var now time.Time
 	if len(nowOpt) > 0 {
 		now = nowOpt[0]
 	} else {
 		now = time.Now()
 	}
-	return &artifficialTimeProvider{
+	return &artificialTimeProvider{
 		now:    now,
 		timers: make([]*timer, 0),
 		mutex:  sync.Mutex{},
 	}
 }
 
-func (atpT *artifficialTimeProvider) SetNow(now time.Time) {
+func (atpT *artificialTimeProvider) SetNow(now time.Time) {
 	atpT.mutex.Lock()
 	defer atpT.mutex.Unlock()
 
@@ -45,14 +45,14 @@ func (atpT *artifficialTimeProvider) SetNow(now time.Time) {
 	atpT.timers = atpT.timers[i:]
 }
 
-func (atpT *artifficialTimeProvider) GetNow() time.Time {
+func (atpT *artificialTimeProvider) GetNow() time.Time {
 	atpT.mutex.Lock()
 	defer atpT.mutex.Unlock()
 
 	return atpT.now
 }
 
-func (atpT *artifficialTimeProvider) After(d time.Duration) <-chan time.Time {
+func (atpT *artificialTimeProvider) After(d time.Duration) <-chan time.Time {
 	channel := make(chan time.Time, 1)
 	if d == 0 {
 		channel <- atpT.now

--- a/packages/util/time_util/time_provider_artifficial_test.go
+++ b/packages/util/time_util/time_provider_artifficial_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-package sm_gpa_utils
+package time_util
 
 import (
 	"testing"

--- a/packages/util/time_util/time_provider_artifficial_test.go
+++ b/packages/util/time_util/time_provider_artifficial_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestArtifficialTimeProvider(t *testing.T) {
+func TestArtificialTimeProvider(t *testing.T) {
 	now := time.Now()
-	tp := NewArtifficialTimeProvider(now)
+	tp := NewArtificialTimeProvider(now)
 	ch30s := tp.After(30 * time.Second)
 	ch40s := tp.After(40 * time.Second)
 	ch20s := tp.After(20 * time.Second)

--- a/packages/util/time_util/time_provider_default.go
+++ b/packages/util/time_util/time_provider_default.go
@@ -1,4 +1,4 @@
-package sm_gpa_utils
+package time_util
 
 import (
 	"time"


### PR DESCRIPTION
The code may be used to mock time in other packages, therefore it was extracted into separate test_util package. This was done on `iota2.0` branch and may be useful here too.