### PR TITLE
Fix cryptolib, fix GetObjectInfo, fix tests

### DIFF
--- a/clients/iscmove/client.go
+++ b/clients/iscmove/client.go
@@ -105,7 +105,7 @@ func (c *Client) StartNewChain(
 		sui.Command{
 			TransferObjects: &sui.ProgrammableTransferObjects{
 				Objects: []sui.Argument{arg1},
-				Address: ptb.MustPure(signer.Address),
+				Address: ptb.MustPure(signer.Address()),
 			},
 		},
 	)
@@ -350,7 +350,7 @@ func (c *Client) CreateRequest(
 		sui.Command{
 			TransferObjects: &sui.ProgrammableTransferObjects{
 				Objects: []sui.Argument{arg1},
-				Address: ptb.MustPure(signer.Address),
+				Address: ptb.MustPure(signer.Address()),
 			},
 		},
 	)

--- a/clients/iscmove/utils_test.go
+++ b/clients/iscmove/utils_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/iotaledger/wasp/clients/iscmove"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/sui-go/contracts"
-	"github.com/iotaledger/wasp/sui-go/suijsonrpc"
-	"github.com/iotaledger/wasp/sui-go/suiclient"
 	"github.com/iotaledger/wasp/sui-go/sui"
+	"github.com/iotaledger/wasp/sui-go/suiclient"
+	"github.com/iotaledger/wasp/sui-go/suijsonrpc"
 )
 
 func buildAndDeployISCContracts(t *testing.T, client *iscmove.Client, signer cryptolib.Signer) *sui.PackageID {

--- a/packages/cryptolib/compatability_test.go
+++ b/packages/cryptolib/compatability_test.go
@@ -1,0 +1,33 @@
+package cryptolib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/wasp/sui-go/sui"
+	"github.com/iotaledger/wasp/sui-go/suisigner"
+)
+
+const (
+	SEEDFORUSER = "0x1234"
+)
+
+func TestCompatability(t *testing.T) {
+	seedIndex := uint32(1)
+	seed := SEEDFORUSER
+
+	kp := KeyPairFromSeed(SubSeed(sui.MustAddressFromHex(seed)[:], seedIndex))
+	subseed := SubSeed(sui.MustAddressFromHex(seed)[:], seedIndex)
+	suikp := suisigner.NewSigner(subseed[:], suisigner.KeySchemeFlagEd25519)
+
+	require.Equal(t, kp.Address().AsSuiAddress().Data(), suikp.Address().Data())
+
+	kpSign, err := kp.SignTransactionBlock([]byte{1, 2, 3, 4}, suisigner.DefaultIntent())
+	require.NoError(t, err)
+
+	suiSign, err := suikp.SignTransactionBlock([]byte{1, 2, 3, 4}, suisigner.DefaultIntent())
+	require.NoError(t, err)
+
+	require.Equal(t, kpSign.AsSuiSignature().Bytes(), suiSign.Bytes())
+}

--- a/packages/cryptolib/compatability_test.go
+++ b/packages/cryptolib/compatability_test.go
@@ -1,25 +1,24 @@
 package cryptolib
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotaledger/wasp/sui-go/sui"
 	"github.com/iotaledger/wasp/sui-go/suisigner"
-)
-
-const (
-	SEEDFORUSER = "0x1234"
 )
 
 func TestCompatability(t *testing.T) {
 	seedIndex := uint32(1)
-	seed := SEEDFORUSER
+	seed := make([]byte, 32)
+	n, err := rand.Read(seed)
+	require.NoError(t, err)
+	require.Equal(t, len(seed), n)
 
-	kp := KeyPairFromSeed(SubSeed(sui.MustAddressFromHex(seed)[:], seedIndex))
-	subseed := SubSeed(sui.MustAddressFromHex(seed)[:], seedIndex)
-	suikp := suisigner.NewSigner(subseed[:], suisigner.KeySchemeFlagEd25519)
+	kp := KeyPairFromSeed(SubSeed(seed, seedIndex))
+	subseed := SubSeed(seed, seedIndex)
+	suikp := suisigner.NewSigner(subseed[:], suisigner.KeySchemeFlagIotaEd25519)
 
 	require.Equal(t, kp.Address().AsSuiAddress().Data(), suikp.Address().Data())
 

--- a/packages/cryptolib/keypair.go
+++ b/packages/cryptolib/keypair.go
@@ -1,7 +1,10 @@
 package cryptolib
 
 import (
+	"crypto/ed25519"
 	"io"
+
+	"golang.org/x/crypto/blake2b"
 
 	"github.com/iotaledger/wasp/packages/util/rwutil"
 	"github.com/iotaledger/wasp/sui-go/suisigner"
@@ -69,9 +72,12 @@ func (k *KeyPair) Sign(payload []byte) (*Signature, error) {
 	return NewSignature(k.GetPublicKey(), k.SignBytes(payload)), nil
 }
 
-func (k *KeyPair) SignTransactionBlock(txnBytes []byte, intent suisigner.Intent) (Signature, error) {
-	//TODO implement me
-	panic("implement me")
+func (k *KeyPair) SignTransactionBlock(txnBytes []byte, intent suisigner.Intent) (*Signature, error) {
+	data := suisigner.MessageWithIntent(intent, txnBytes)
+	hash := blake2b.Sum256(data)
+	sig := ed25519.Sign(k.privateKey.key, hash[:])
+
+	return NewSignature(k.GetPublicKey(), sig), nil
 }
 
 func (k *KeyPair) Read(r io.Reader) error {

--- a/packages/cryptolib/public_key.go
+++ b/packages/cryptolib/public_key.go
@@ -9,9 +9,10 @@ import (
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 
+	"github.com/minio/blake2b-simd"
+
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/util/rwutil"
-	"github.com/minio/blake2b-simd"
 )
 
 type PublicKey struct {
@@ -69,7 +70,8 @@ func (pkT *PublicKey) AsKey() PublicKeyKey {
 }
 
 func (pkT *PublicKey) AsAddress() *Address {
-	typeKey := []byte{0}
+	// TODO: Clarify the typeKey here. The SUI/IOTA Scheme does not have a typeKey, previously it was {0}
+	typeKey := []byte{}
 	typeKey = append(typeKey, pkT.key...)
 	return newAddressFromArray(blake2b.Sum256(typeKey))
 }

--- a/packages/cryptolib/signer.go
+++ b/packages/cryptolib/signer.go
@@ -1,8 +1,8 @@
 package cryptolib
 
 import (
-	"github.com/iotaledger/wasp/sui-go/suisigner"
 	"github.com/iotaledger/wasp/sui-go/sui"
+	"github.com/iotaledger/wasp/sui-go/suisigner"
 )
 
 // VariantKeyPair originates from KeyPair
@@ -12,7 +12,7 @@ type Signer interface {
 
 	Address() *Address
 	Sign(msg []byte) (signature *Signature, err error)
-	SignTransactionBlock(txnBytes []byte, intent suisigner.Intent) (Signature, error)
+	SignTransactionBlock(txnBytes []byte, intent suisigner.Intent) (*Signature, error)
 }
 
 type suiSigner struct {

--- a/sui-go/suiclient/extend_calls.go
+++ b/sui-go/suiclient/extend_calls.go
@@ -19,10 +19,12 @@ func (s *Client) GetCoinObjsForTargetAmount(
 	address *sui.Address,
 	targetAmount uint64,
 ) (suijsonrpc.Coins, error) {
-	coins, err := s.GetCoins(ctx, GetCoinsRequest{
-		Owner: address,
-		Limit: 200,
-	})
+	coins, err := s.GetCoins(
+		ctx, GetCoinsRequest{
+			Owner: address,
+			Limit: 200,
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call GetCoins(): %w", err)
 	}
@@ -82,7 +84,7 @@ func (s *Client) PublishContract(
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to publish move contract: %w", err)
 	}
-	txnResponse, err := s.SignAndExecuteTransaction(context.Background(), signer, txnBytes.TxBytes, options)
+	txnResponse, err := s.SignAndExecuteTransaction(ctx, signer, txnBytes.TxBytes, options)
 	if err != nil || !txnResponse.Effects.Data.IsSuccess() {
 		return nil, nil, fmt.Errorf("failed to sign move contract tx: %w", err)
 	}
@@ -132,10 +134,12 @@ const QUERY_MAX_RESULT_LIMIT = 50
 
 // GetSuiCoinsOwnedByAddress This function will retrieve a maximum of 200 coins.
 func (s *Client) GetSuiCoinsOwnedByAddress(ctx context.Context, address *sui.Address) (suijsonrpc.Coins, error) {
-	page, err := s.GetCoins(ctx, GetCoinsRequest{
-		Owner: address,
-		Limit: 200,
-	})
+	page, err := s.GetCoins(
+		ctx, GetCoinsRequest{
+			Owner: address,
+			Limit: 200,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -163,14 +167,16 @@ func (s *Client) BatchGetFilteredObjectsOwnedByAddress(
 	options *suijsonrpc.SuiObjectDataOptions,
 	filter func(*suijsonrpc.SuiObjectData) bool,
 ) ([]suijsonrpc.SuiObjectResponse, error) {
-	filteringObjs, err := s.GetOwnedObjects(ctx, GetOwnedObjectsRequest{
-		Address: address,
-		Query: &suijsonrpc.SuiObjectResponseQuery{
-			Options: &suijsonrpc.SuiObjectDataOptions{
-				ShowType: true,
+	filteringObjs, err := s.GetOwnedObjects(
+		ctx, GetOwnedObjectsRequest{
+			Address: address,
+			Query: &suijsonrpc.SuiObjectResponseQuery{
+				Options: &suijsonrpc.SuiObjectDataOptions{
+					ShowType: true,
+				},
 			},
 		},
-	})
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -185,10 +191,12 @@ func (s *Client) BatchGetFilteredObjectsOwnedByAddress(
 		objIds = append(objIds, obj.Data.ObjectID)
 	}
 
-	return s.MultiGetObjects(ctx, MultiGetObjectsRequest{
-		ObjectIDs: objIds,
-		Options:   options,
-	})
+	return s.MultiGetObjects(
+		ctx, MultiGetObjectsRequest{
+			ObjectIDs: objIds,
+			Options:   options,
+		},
+	)
 }
 
 ////// PTB impl

--- a/sui-go/suijsonrpc/transactions.go
+++ b/sui-go/suijsonrpc/transactions.go
@@ -324,18 +324,18 @@ func (r *SuiTransactionBlockResponse) GetCreatedObjectInfo(module string, object
 			}
 			if resource.Module == module && resource.ObjectName == objectName {
 				ref := sui.ObjectRef{
-					ObjectID: &change.Data.Published.PackageId,
-					Version:  change.Data.Published.Version.Uint64(),
-					Digest:   &change.Data.Published.Digest,
+					ObjectID: &change.Data.Created.ObjectID,
+					Version:  change.Data.Created.Version.Uint64(),
+					Digest:   &change.Data.Created.Digest,
 				}
 				return &ref, nil
 			}
 			for ; resource.SubType != nil; resource = resource.SubType {
 				if resource.Module == module && resource.ObjectName == objectName {
 					ref := sui.ObjectRef{
-						ObjectID: &change.Data.Published.PackageId,
-						Version:  change.Data.Published.Version.Uint64(),
-						Digest:   &change.Data.Published.Digest,
+						ObjectID: &change.Data.Created.ObjectID,
+						Version:  change.Data.Created.Version.Uint64(),
+						Digest:   &change.Data.Created.Digest,
 					}
 					return &ref, nil
 				}

--- a/sui-go/suisigner/key_schemes.go
+++ b/sui-go/suisigner/key_schemes.go
@@ -7,7 +7,7 @@ import (
 
 type KeySchemeFlag byte
 
-var KeySchemeFlagDefault = KeySchemeFlagEd25519
+var KeySchemeFlagDefault = KeySchemeFlagIotaEd25519
 
 const (
 	KeySchemeFlagEd25519 KeySchemeFlag = iota

--- a/sui-go/suisigner/key_schemes.go
+++ b/sui-go/suisigner/key_schemes.go
@@ -17,8 +17,8 @@ const (
 	KeySchemeFlagBLS12381
 	KeySchemeFlagZkLoginAuthenticator
 
-	KeySchemeFlagIotaEd25519 = math.MaxUint8 - 1 // special case for iota ed25519
-	KeySchemeFlagError       = math.MaxUint8
+	KeySchemeFlagIotaEd25519 KeySchemeFlag = math.MaxUint8 - 1 // special case for iota ed25519
+	KeySchemeFlagError                     = math.MaxUint8
 )
 
 func (k KeySchemeFlag) Byte() byte {

--- a/sui-go/suisigner/signer_test.go
+++ b/sui-go/suisigner/signer_test.go
@@ -60,8 +60,8 @@ func ExampleSigner() {
 	fmt.Printf("address   : %v\n", signer2.Address())
 
 	// Output:
-	// address   : 0xe54d993cf56be93ba0764c7ee2c817085b70f0e6d3ad1a71c3335ee3529b4a48
+	// address   : 0x786dff8a4ee13d45b502c8f22f398e3517e6ec78aa4ae564c348acb07fad7f50
 	// privateKey: 4ec5a9eefc0bb86027a6f3ba718793c813505acc25ed09447caf6a069accdd4b
 	// publicKey : 9342fa65507f5cf61f1b8fb3b94a5aa80fa9b2e2c68963e30d68a2660a50c57e
-	// address   : 0x579a9ef1ca86431df106abb86f1f129806cd336b28f5bc17d16ce247aa3a0623
+	// address   : 0x07e542f628f0e48950578aaff3e0c0566b6dccfc7cc248d9941308b47e934e6a
 }


### PR DESCRIPTION
* Fixes cryptolib 
* Fixes tests
* Fixes client not using Address correctly
* Fixes `GetCreatedObjectInfo` to use Created items again
* Made `KeySchemeFlagDefault = KeySchemeFlagIotaEd25519`

(This will make ISC incompatible with official SUI testnets, but is the only way to use our iota-test-validator)