### PR TITLE
Client and metadata refactoring  

### DIFF
--- a/clients/chainclient/chainclient.go
+++ b/clients/chainclient/chainclient.go
@@ -6,20 +6,20 @@ import (
 	"math"
 
 	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/clients/apiextensions"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
-	"github.com/iotaledger/wasp/packages/l2connection"
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 )
 
 // Client allows to interact with a specific chain in the node, for example to send on-ledger or off-ledger requests
 type Client struct {
-	Layer2Client l2connection.Client
+	Layer2Client clients.L2Client
 	WaspClient   *apiclient.APIClient
 	ChainID      isc.ChainID
 	KeyPair      cryptolib.Signer
@@ -27,7 +27,7 @@ type Client struct {
 
 // New creates a new chainclient.Client
 func New(
-	layer2Client l2connection.Client,
+	layer2Client clients.L2Client,
 	waspClient *apiclient.APIClient,
 	chainID isc.ChainID,
 	keyPair cryptolib.Signer,

--- a/clients/chainclient/chainclient.go
+++ b/clients/chainclient/chainclient.go
@@ -19,7 +19,7 @@ import (
 
 // Client allows to interact with a specific chain in the node, for example to send on-ledger or off-ledger requests
 type Client struct {
-	Layer2Client clients.L2Client
+	Layer1Client clients.L1Client
 	WaspClient   *apiclient.APIClient
 	ChainID      isc.ChainID
 	KeyPair      cryptolib.Signer
@@ -27,13 +27,13 @@ type Client struct {
 
 // New creates a new chainclient.Client
 func New(
-	layer2Client clients.L2Client,
+	layer1Client clients.L1Client,
 	waspClient *apiclient.APIClient,
 	chainID isc.ChainID,
 	keyPair cryptolib.Signer,
 ) *Client {
 	return &Client{
-		Layer2Client: layer2Client,
+		Layer1Client: layer1Client,
 		WaspClient:   waspClient,
 		ChainID:      chainID,
 		KeyPair:      keyPair,

--- a/clients/iscmove/client.go
+++ b/clients/iscmove/client.go
@@ -12,16 +12,13 @@ import (
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/sui-go/sui"
 	"github.com/iotaledger/wasp/sui-go/suiclient"
-	"github.com/iotaledger/wasp/sui-go/suiconn"
 	"github.com/iotaledger/wasp/sui-go/suijsonrpc"
 )
 
 // Client provides convenient methods to interact with the `isc` Move contracts.
 type Config struct {
-	APIURL       string
-	FaucetURL    string
-	GraphURL     string
-	WebsocketURL string
+	APIURL   string
+	GraphURL string
 }
 
 type Client struct {
@@ -37,28 +34,6 @@ func NewClient(config Config) *Client {
 		NewGraph(config.GraphURL),
 		config,
 	}
-}
-
-func (c *Client) RequestFunds(ctx context.Context, address cryptolib.Address) error {
-	var faucetURL string = c.config.FaucetURL
-	if faucetURL == "" {
-		switch c.config.APIURL {
-		case suiconn.TestnetEndpointURL:
-			faucetURL = suiconn.TestnetFaucetURL
-		case suiconn.DevnetEndpointURL:
-			faucetURL = suiconn.DevnetFaucetURL
-		case suiconn.LocalnetEndpointURL:
-			faucetURL = suiconn.LocalnetFaucetURL
-		default:
-			panic("unspecified FaucetURL")
-		}
-	}
-	return suiclient.RequestFundsFromFaucet(address.AsSuiAddress(), faucetURL)
-}
-
-func (c *Client) Health(ctx context.Context) error {
-	_, err := c.GetLatestSuiSystemState(ctx)
-	return err
 }
 
 // StartNewChain calls <packageID>::anchor::start_new_chain(), and then transfers the created

--- a/clients/iscmove/client_test.go
+++ b/clients/iscmove/client_test.go
@@ -388,7 +388,7 @@ func TestSendReceiveRequest(t *testing.T) {
 
 func newSignerWithFunds(t *testing.T, seed string) cryptolib.Signer {
 	kp := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(sui.MustAddressFromHex(seed)[:], 0))
-	err := suiclient.RequestFundsFromFaucet(kp.Address().AsSuiAddress(), suiconn.LocalnetFaucetURL)
+	err := suiclient.RequestFundsFromFaucet(context.Background(), kp.Address().AsSuiAddress(), suiconn.LocalnetFaucetURL)
 	require.NoError(t, err)
 	return kp
 }

--- a/clients/l1client.go
+++ b/clients/l1client.go
@@ -1,0 +1,236 @@
+package clients
+
+import (
+	"context"
+
+	"github.com/iotaledger/wasp/packages/cryptolib"
+	"github.com/iotaledger/wasp/sui-go/sui"
+	"github.com/iotaledger/wasp/sui-go/suiclient"
+	"github.com/iotaledger/wasp/sui-go/suiconn"
+	"github.com/iotaledger/wasp/sui-go/suijsonrpc"
+	"github.com/iotaledger/wasp/sui-go/suisigner"
+)
+
+type L1Config struct {
+	FaucetURL string
+	APIURL    string
+}
+
+type L1ClientExt struct {
+	*suiclient.Client
+
+	Config L1Config
+}
+
+func (c *L1ClientExt) RequestFunds(ctx context.Context, address cryptolib.Address) error {
+	var faucetURL string = c.Config.FaucetURL
+	if faucetURL == "" {
+		switch c.Config.APIURL {
+		case suiconn.TestnetEndpointURL:
+			faucetURL = suiconn.TestnetFaucetURL
+		case suiconn.DevnetEndpointURL:
+			faucetURL = suiconn.DevnetFaucetURL
+		case suiconn.LocalnetEndpointURL:
+			faucetURL = suiconn.LocalnetFaucetURL
+		default:
+			panic("unspecified FaucetURL")
+		}
+	}
+
+	return suiclient.RequestFundsFromFaucet(ctx, address.AsSuiAddress(), faucetURL)
+}
+
+func (c *L1ClientExt) Health(ctx context.Context) error {
+	_, err := c.Client.GetLatestSuiSystemState(ctx)
+	return err
+}
+
+func NewL1Client(l1Config L1Config) L1Client {
+	return &L1ClientExt{
+		suiclient.New(l1Config.APIURL),
+		l1Config,
+	}
+}
+
+type L1Client interface {
+	GetDynamicFieldObject(
+		ctx context.Context,
+		req suiclient.GetDynamicFieldObjectRequest,
+	) (*suijsonrpc.SuiObjectResponse, error)
+	GetDynamicFields(
+		ctx context.Context,
+		req suiclient.GetDynamicFieldsRequest,
+	) (*suijsonrpc.DynamicFieldPage, error)
+	GetOwnedObjects(
+		ctx context.Context,
+		req suiclient.GetOwnedObjectsRequest,
+	) (*suijsonrpc.ObjectsPage, error)
+	QueryEvents(
+		ctx context.Context,
+		req suiclient.QueryEventsRequest,
+	) (*suijsonrpc.EventPage, error)
+	QueryTransactionBlocks(
+		ctx context.Context,
+		req suiclient.QueryTransactionBlocksRequest,
+	) (*suijsonrpc.TransactionBlocksPage, error)
+	ResolveNameServiceAddress(ctx context.Context, suiName string) (*sui.Address, error)
+	ResolveNameServiceNames(
+		ctx context.Context,
+		req suiclient.ResolveNameServiceNamesRequest,
+	) (*suijsonrpc.SuiNamePage, error)
+	SubscribeEvent(
+		ctx context.Context,
+		filter *suijsonrpc.EventFilter,
+		resultCh chan suijsonrpc.SuiEvent,
+	) error
+	DevInspectTransactionBlock(
+		ctx context.Context,
+		req suiclient.DevInspectTransactionBlockRequest,
+	) (*suijsonrpc.DevInspectResults, error)
+	DryRunTransaction(
+		ctx context.Context,
+		txDataBytes sui.Base64Data,
+	) (*suijsonrpc.DryRunTransactionBlockResponse, error)
+	ExecuteTransactionBlock(
+		ctx context.Context,
+		req suiclient.ExecuteTransactionBlockRequest,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	GetCommitteeInfo(
+		ctx context.Context,
+		epoch *suijsonrpc.BigInt, // optional
+
+	) (*suijsonrpc.CommitteeInfo, error)
+	GetLatestSuiSystemState(ctx context.Context) (*suijsonrpc.SuiSystemStateSummary, error)
+	GetReferenceGasPrice(ctx context.Context) (*suijsonrpc.BigInt, error)
+	GetStakes(ctx context.Context, owner *sui.Address) ([]*suijsonrpc.DelegatedStake, error)
+	GetStakesByIds(ctx context.Context, stakedSuiIds []sui.ObjectID) ([]*suijsonrpc.DelegatedStake, error)
+	GetValidatorsApy(ctx context.Context) (*suijsonrpc.ValidatorsApy, error)
+	BatchTransaction(
+		ctx context.Context,
+		req suiclient.BatchTransactionRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	MergeCoins(
+		ctx context.Context,
+		req suiclient.MergeCoinsRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	MoveCall(
+		ctx context.Context,
+		req suiclient.MoveCallRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	Pay(
+		ctx context.Context,
+		req suiclient.PayRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	PayAllSui(
+		ctx context.Context,
+		req suiclient.PayAllSuiRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	PaySui(
+		ctx context.Context,
+		req suiclient.PaySuiRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	Publish(
+		ctx context.Context,
+		req suiclient.PublishRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	RequestAddStake(
+		ctx context.Context,
+		req suiclient.RequestAddStakeRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	RequestWithdrawStake(
+		ctx context.Context,
+		req suiclient.RequestWithdrawStakeRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	SplitCoin(
+		ctx context.Context,
+		req suiclient.SplitCoinRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	SplitCoinEqual(
+		ctx context.Context,
+		req suiclient.SplitCoinEqualRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	TransferObject(
+		ctx context.Context,
+		req suiclient.TransferObjectRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	TransferSui(
+		ctx context.Context,
+		req suiclient.TransferSuiRequest,
+	) (*suijsonrpc.TransactionBytes, error)
+	GetCoinObjsForTargetAmount(
+		ctx context.Context,
+		address *sui.Address,
+		targetAmount uint64,
+	) (suijsonrpc.Coins, error)
+	SignAndExecuteTransaction(
+		ctx context.Context,
+		signer suisigner.Signer,
+		txBytes sui.Base64Data,
+		options *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	PublishContract(
+		ctx context.Context,
+		signer suisigner.Signer,
+		modules []*sui.Base64Data,
+		dependencies []*sui.Address,
+		gasBudget uint64,
+		options *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, *sui.PackageID, error)
+	MintToken(
+		ctx context.Context,
+		signer suisigner.Signer,
+		packageID *sui.PackageID,
+		tokenName string,
+		treasuryCap *sui.ObjectID,
+		mintAmount uint64,
+		options *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	GetSuiCoinsOwnedByAddress(ctx context.Context, address *sui.Address) (suijsonrpc.Coins, error)
+	BatchGetObjectsOwnedByAddress(
+		ctx context.Context,
+		address *sui.Address,
+		options *suijsonrpc.SuiObjectDataOptions,
+		filterType string,
+	) ([]suijsonrpc.SuiObjectResponse, error)
+	BatchGetFilteredObjectsOwnedByAddress(
+		ctx context.Context,
+		address *sui.Address,
+		options *suijsonrpc.SuiObjectDataOptions,
+		filter func(*suijsonrpc.SuiObjectData) bool,
+	) ([]suijsonrpc.SuiObjectResponse, error)
+	GetAllBalances(ctx context.Context, owner *sui.Address) ([]*suijsonrpc.Balance, error)
+	GetAllCoins(ctx context.Context, req suiclient.GetAllCoinsRequest) (*suijsonrpc.CoinPage, error)
+	GetBalance(ctx context.Context, req suiclient.GetBalanceRequest) (*suijsonrpc.Balance, error)
+	GetCoinMetadata(ctx context.Context, coinType string) (*suijsonrpc.SuiCoinMetadata, error)
+	GetCoins(ctx context.Context, req suiclient.GetCoinsRequest) (*suijsonrpc.CoinPage, error)
+	GetTotalSupply(ctx context.Context, coinType sui.ObjectType) (*suijsonrpc.Supply, error)
+	GetChainIdentifier(ctx context.Context) (string, error)
+	GetCheckpoint(ctx context.Context, checkpointId *suijsonrpc.BigInt) (*suijsonrpc.Checkpoint, error)
+	GetCheckpoints(ctx context.Context, req suiclient.GetCheckpointsRequest) (*suijsonrpc.CheckpointPage, error)
+	GetEvents(ctx context.Context, digest *sui.TransactionDigest) ([]*suijsonrpc.SuiEvent, error)
+	GetLatestCheckpointSequenceNumber(ctx context.Context) (string, error)
+	GetObject(ctx context.Context, req suiclient.GetObjectRequest) (*suijsonrpc.SuiObjectResponse, error)
+	GetProtocolConfig(
+		ctx context.Context,
+		version *suijsonrpc.BigInt, // optional
+	) (*suijsonrpc.ProtocolConfig, error)
+	GetTotalTransactionBlocks(ctx context.Context) (string, error)
+	GetTransactionBlock(ctx context.Context, req suiclient.GetTransactionBlockRequest) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	MultiGetObjects(ctx context.Context, req suiclient.MultiGetObjectsRequest) ([]suijsonrpc.SuiObjectResponse, error)
+	MultiGetTransactionBlocks(
+		ctx context.Context,
+		req suiclient.MultiGetTransactionBlocksRequest,
+	) ([]*suijsonrpc.SuiTransactionBlockResponse, error)
+	TryGetPastObject(
+		ctx context.Context,
+		req suiclient.TryGetPastObjectRequest,
+	) (*suijsonrpc.SuiPastObjectResponse, error)
+	TryMultiGetPastObjects(
+		ctx context.Context,
+		req suiclient.TryMultiGetPastObjectsRequest,
+	) ([]*suijsonrpc.SuiPastObjectResponse, error)
+	WithSignerAndFund(seed []byte, index int) (*suiclient.Client, suisigner.Signer)
+	RequestFunds(ctx context.Context, address cryptolib.Address) error
+	Health(ctx context.Context) error
+	WithWebsocket(url string)
+}

--- a/clients/l2client.go
+++ b/clients/l2client.go
@@ -1,5 +1,5 @@
 // to be used by utilities like: cluster-tool, wasp-cli, apilib, etc
-package l2connection
+package clients
 
 import (
 	"context"
@@ -10,18 +10,7 @@ import (
 	"github.com/iotaledger/wasp/sui-go/suijsonrpc"
 )
 
-type Config struct {
-	APIAddress    string
-	INXAddress    string
-	FaucetAddress string
-	FaucetKey     *cryptolib.KeyPair
-	UseRemotePoW  bool
-}
-
-type Client interface {
-	RequestFunds(ctx context.Context, address cryptolib.Address) error
-	Health(ctx context.Context) error
-
+type L2Client interface {
 	StartNewChain(
 		ctx context.Context,
 		signer cryptolib.Signer,
@@ -34,4 +23,8 @@ type Client interface {
 	) (*iscmove.Anchor, error)
 }
 
-var _ Client = &iscmove.Client{}
+var _ L2Client = &iscmove.Client{}
+
+func NewL2Client(config iscmove.Config) L2Client {
+	return iscmove.NewClient(config)
+}

--- a/clients/l2client.go
+++ b/clients/l2client.go
@@ -21,6 +21,70 @@ type L2Client interface {
 		execOptions *suijsonrpc.SuiTransactionBlockResponseOptions,
 		treasuryCap *suijsonrpc.SuiObjectResponse,
 	) (*iscmove.Anchor, error)
+	SendCoin(
+		ctx context.Context,
+		signer cryptolib.Signer,
+		anchorPackageID *sui.PackageID,
+		anchorAddress *sui.ObjectID,
+		coinType string,
+		coinObject *sui.ObjectID,
+		gasPayments []*sui.ObjectRef, // optional
+		gasPrice uint64, // TODO use gasPrice when we change MoveCall API to PTB version
+		gasBudget uint64,
+		execOptions *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	ReceiveCoin(
+		ctx context.Context,
+		signer cryptolib.Signer,
+		anchorPackageID *sui.PackageID,
+		anchorAddress *sui.ObjectID,
+		coinType string,
+		receivingCoinObject *sui.ObjectID,
+		gasPayments []*sui.ObjectRef, // optional
+		gasPrice uint64, // TODO use gasPrice when we change MoveCall API to PTB version
+		gasBudget uint64,
+		execOptions *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	GetAssets(
+		ctx context.Context,
+		anchorPackageID *sui.PackageID,
+		anchorAddress *sui.ObjectID,
+	) (*iscmove.Assets, error)
+	CreateRequest(
+		ctx context.Context,
+		signer cryptolib.Signer,
+		packageID *sui.PackageID,
+		anchorAddress *sui.ObjectID,
+		iscContractName string,
+		iscFunctionName string,
+		args [][]byte,
+		gasPayments []*sui.ObjectRef, // optional
+		gasPrice uint64,
+		gasBudget uint64,
+		execOptions *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	SendRequest(
+		ctx context.Context,
+		signer cryptolib.Signer,
+		packageID *sui.PackageID,
+		anchorAddress *sui.ObjectID,
+		reqObjID *sui.ObjectID,
+		gasPayments []*sui.ObjectRef, // optional
+		gasPrice uint64, // TODO use gasPrice when we change MoveCall API to PTB version
+		gasBudget uint64,
+		execOptions *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
+	ReceiveRequest(
+		ctx context.Context,
+		signer cryptolib.Signer,
+		packageID *sui.PackageID,
+		anchorAddress *sui.ObjectID,
+		reqObjID *sui.ObjectID,
+		gasPayments []*sui.ObjectRef, // optional
+		gasPrice uint64, // TODO use gasPrice when we change MoveCall API to PTB version
+		gasBudget uint64,
+		execOptions *suijsonrpc.SuiTransactionBlockResponseOptions,
+	) (*suijsonrpc.SuiTransactionBlockResponse, error)
 }
 
 var _ L2Client = &iscmove.Client{}

--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -21,7 +21,7 @@ import (
 // TODO DeployChain on peering domain, not on committee
 
 type CreateChainParams struct {
-	Layer2Client         clients.L2Client
+	Layer1Client         clients.L1Client
 	CommitteeAPIHosts    []string
 	N                    uint16
 	T                    uint16
@@ -47,7 +47,7 @@ func DeployChain(par CreateChainParams, stateControllerAddr, govControllerAddr *
 	fmt.Fprint(textout, par.Prefix)
 
 	chainID, err := CreateChainOrigin(
-		par.Layer2Client,
+		par.Layer1Client,
 		par.OriginatorKeyPair,
 		stateControllerAddr,
 		govControllerAddr,
@@ -77,7 +77,7 @@ func utxoIDsFromUtxoMap(utxoMap iotago.OutputSet) iotago.OutputIDs {
 
 // CreateChainOrigin creates and confirms origin transaction of the chain and init request transaction to initialize state of it
 func CreateChainOrigin(
-	layer2Client clients.L2Client,
+	layer1Client clients.L1Client,
 	originator cryptolib.Signer,
 	stateController *cryptolib.Address,
 	governanceController *cryptolib.Address,

--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -9,11 +9,11 @@ import (
 	"io"
 
 	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/clients/multiclient"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/dict"
-	"github.com/iotaledger/wasp/packages/l2connection"
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/registry"
 )
@@ -21,7 +21,7 @@ import (
 // TODO DeployChain on peering domain, not on committee
 
 type CreateChainParams struct {
-	Layer2Client         l2connection.Client
+	Layer2Client         clients.L2Client
 	CommitteeAPIHosts    []string
 	N                    uint16
 	T                    uint16
@@ -77,7 +77,7 @@ func utxoIDsFromUtxoMap(utxoMap iotago.OutputSet) iotago.OutputIDs {
 
 // CreateChainOrigin creates and confirms origin transaction of the chain and init request transaction to initialize state of it
 func CreateChainOrigin(
-	layer2Client l2connection.Client,
+	layer2Client clients.L2Client,
 	originator cryptolib.Signer,
 	stateController *cryptolib.Address,
 	governanceController *cryptolib.Address,

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -293,17 +293,21 @@ func (ncc *ncChain) postTxLoop(ctx context.Context) {
 	}()
 
 	checkTransactionIncludedAndSetConfirmed := func(pendingTx *pendingTransaction) bool {
-		ctxWithTimeout, ctxCancel := context.WithTimeout(nodeConn.ctx, inxTimeoutBlockMetadata)
-		defer ctxCancel()
+		panic("refactor me: parameters.L1()")
+		/*
+				ctxWithTimeout, ctxCancel := context.WithTimeout(nodeConn.ctx, inxTimeoutBlockMetadata)
+				defer ctxCancel()
 
-		// check if the transaction was already included (race condition with other validators)
-		if _, err := ncc.nodeConn.nodeClient.TransactionIncludedBlock(ctxWithTimeout, pendingTx.ID(), parameters.L1().Protocol); err == nil {
-			// transaction was already included
-			pendingTx.SetConfirmed()
-			return true
-		}
+				// check if the transaction was already included (race condition with other validators)
+				if _, err := ncc.nodeConn.nodeClient.TransactionIncludedBlock(ctxWithTimeout, pendingTx.ID(), parameters.L1().Protocol); err == nil {
+					// transaction was already included
+					pendingTx.SetConfirmed()
+					return true
+				}
 
-		return false
+			return false
+		
+		*/
 	}
 
 	checkIsPending := func(pendingTx *pendingTransaction) bool {

--- a/packages/nodeconn/nodeconn.go
+++ b/packages/nodeconn/nodeconn.go
@@ -248,14 +248,15 @@ func waitForL1ToBeSynced(ctx context.Context, log *logger.Logger, nodeBridge *no
 }
 
 func (nc *nodeConnection) setL1ProtocolParams(protocolParameters *iotago.ProtocolParameters, baseToken *nodeclient.InfoResBaseToken) {
-	nc.l1Params = &parameters.L1Params{
+	panic("refactor me: L1Params")
+	/*nc.l1Params = &parameters.L1Params{
 		// There are no limits on how big from a size perspective an essence can be,
 		// so it is just derived from 32KB - Block fields without payload = max size of the payload
 		MaxPayloadSize: parameters.MaxPayloadSize,
 		Protocol:       protocolParameters,
 		BaseToken:      (*parameters.BaseToken)(baseToken),
 	}
-	parameters.InitL1(nc.l1Params)
+	parameters.InitL1(nc.l1Params)*/
 }
 
 func (nc *nodeConnection) Run(ctx context.Context) error {

--- a/packages/origin/origin.go
+++ b/packages/origin/origin.go
@@ -1,7 +1,6 @@
 package origin
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -11,9 +10,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
-	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/state"
-	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/blob"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
@@ -85,9 +82,13 @@ func InitChainByAliasOutput(chainStore state.Store, aliasOutput *isc.AliasOutput
 			return nil, fmt.Errorf("invalid parameters on origin AO, %w", err)
 		}
 	}
-	l1params := parameters.L1()
-	aoMinSD := l1params.Protocol.RentStructure.MinRent(aliasOutput.GetAliasOutput())
-	commonAccountAmount := aliasOutput.GetAliasOutput().Amount - aoMinSD
+
+	panic("refactor me: parameters.L1() / RentStructure")
+	_ = initParams
+	// l1params := parameters.L1()
+	//aoMinSD := l1params.Protocol.RentStructure.MinRent(aliasOutput.GetAliasOutput())
+
+	/* commonAccountAmount := aliasOutput.GetAliasOutput().Amount - aoMinSD
 	originAOStateMetadata, err := transaction.StateMetadataFromBytes(aliasOutput.GetStateMetadata())
 	originBlock := InitChain(originAOStateMetadata.SchemaVersion, chainStore, initParams, commonAccountAmount)
 
@@ -110,5 +111,7 @@ func InitChainByAliasOutput(chainStore state.Store, aliasOutput *isc.AliasOutput
 			string(l1paramsJSON),
 		)
 	}
-	return originBlock, nil
+	return originBlock, nil */
+
+	return nil, nil
 }

--- a/packages/parameters/l1parameters.go
+++ b/packages/parameters/l1parameters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/hive.go/serializer/v2"
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/iota.go/v3/tpkg"
+	"github.com/iotaledger/wasp/sui-go/suijsonrpc"
 )
 
 // L1Params describes parameters coming from the L1Params node
@@ -17,13 +18,16 @@ type L1Params struct {
 	BaseToken      *BaseToken                 `json:"baseToken" swagger:"required"`
 }
 
+const CoinTypeBaseToken suijsonrpc.CoinType = "0x2::sui::SUI"
+
 type BaseToken struct {
-	Name            string `json:"name" swagger:"desc(The base token name),required"`
-	TickerSymbol    string `json:"tickerSymbol" swagger:"desc(The ticker symbol),required"`
-	Unit            string `json:"unit" swagger:"desc(The token unit),required"`
-	Subunit         string `json:"subunit" swagger:"desc(The token subunit),required"`
-	Decimals        uint32 `json:"decimals" swagger:"desc(The token decimals),required"`
-	UseMetricPrefix bool   `json:"useMetricPrefix" swagger:"desc(Whether or not the token uses a metric prefix),required"`
+	Name            string              `json:"name" swagger:"desc(The base token name),required"`
+	TickerSymbol    string              `json:"tickerSymbol" swagger:"desc(The ticker symbol),required"`
+	Unit            string              `json:"unit" swagger:"desc(The token unit),required"`
+	Subunit         string              `json:"subunit" swagger:"desc(The token subunit),required"`
+	Decimals        uint32              `json:"decimals" swagger:"desc(The token decimals),required"`
+	UseMetricPrefix bool                `json:"useMetricPrefix" swagger:"desc(Whether or not the token uses a metric prefix),required"`
+	CoinType        suijsonrpc.CoinType `json:"coinType"`
 }
 
 // NetworkPrefix denotes the different network prefixes.
@@ -32,9 +36,6 @@ type NetworkPrefix string
 // Network prefixes.
 const (
 	PrefixMainnet NetworkPrefix = "iota"
-	PrefixDevnet  NetworkPrefix = "atoi"
-	PrefixShimmer NetworkPrefix = "smr"
-	PrefixTestnet NetworkPrefix = "rms"
 )
 
 const Bech32Hrp = PrefixMainnet
@@ -48,6 +49,7 @@ var Token = &BaseToken{
 	Subunit:         "IOTA",
 	Decimals:        6,
 	UseMetricPrefix: false,
+	CoinType:        CoinTypeBaseToken,
 }
 
 const MaxPayloadSize = iotago.BlockBinSerializedMaxSize - // BlockSizeMax

--- a/packages/parameters/l1parameters.go
+++ b/packages/parameters/l1parameters.go
@@ -39,6 +39,16 @@ const (
 
 const Bech32Hrp = PrefixMainnet
 const Decimals = 6
+const NetworkName = "testnet"
+
+var Token = &BaseToken{
+	Name:            "Iota",
+	TickerSymbol:    "MIOTA",
+	Unit:            "MIOTA",
+	Subunit:         "IOTA",
+	Decimals:        6,
+	UseMetricPrefix: false,
+}
 
 const MaxPayloadSize = iotago.BlockBinSerializedMaxSize - // BlockSizeMax
 	serializer.OneByte - // ProtocolVersion

--- a/packages/parameters/l1parameters.go
+++ b/packages/parameters/l1parameters.go
@@ -18,8 +18,6 @@ type L1Params struct {
 	BaseToken      *BaseToken                 `json:"baseToken" swagger:"required"`
 }
 
-const CoinTypeBaseToken suijsonrpc.CoinType = "0x2::sui::SUI"
-
 type BaseToken struct {
 	Name            string              `json:"name" swagger:"desc(The base token name),required"`
 	TickerSymbol    string              `json:"tickerSymbol" swagger:"desc(The ticker symbol),required"`
@@ -49,7 +47,7 @@ var Token = &BaseToken{
 	Subunit:         "IOTA",
 	Decimals:        6,
 	UseMetricPrefix: false,
-	CoinType:        CoinTypeBaseToken,
+	CoinType:        suijsonrpc.SuiCoinType,
 }
 
 const MaxPayloadSize = iotago.BlockBinSerializedMaxSize - // BlockSizeMax

--- a/packages/solo/evm.go
+++ b/packages/solo/evm.go
@@ -127,7 +127,7 @@ func (b *jsonRPCSoloBackend) TakeSnapshot() (int, error) {
 
 func (ch *Chain) EVM() *jsonrpc.EVMChain {
 	return jsonrpc.NewEVMChain(
-		newJSONRPCSoloBackend(ch, parameters.L1().BaseToken),
+		newJSONRPCSoloBackend(ch, parameters.Token),
 		ch.Env.publisher,
 		true,
 		hivedb.EngineMapDB,

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -17,7 +17,6 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
-	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/trie"
@@ -362,18 +361,21 @@ func (ch *Chain) EstimateGasOffLedger(req *CallParams, keyPair cryptolib.Signer)
 // needed to add to the request (if any) in order to cover for the storage
 // deposit.
 func (ch *Chain) EstimateNeededStorageDeposit(req *CallParams, keyPair cryptolib.Signer) uint64 {
-	out := transaction.MakeRequestTransactionOutput(ch.requestTransactionParams(req, keyPair))
-	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)
+	panic("refactor me: parameters.L1() / RentStructure")
+	/*
+		out := transaction.MakeRequestTransactionOutput(ch.requestTransactionParams(req, keyPair))
 
-	reqDeposit := uint64(0)
-	if req.ftokens != nil {
-		reqDeposit = req.ftokens.BaseTokens
-	}
+		storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)
 
-	if reqDeposit >= storageDeposit {
-		return 0
-	}
-	return storageDeposit - reqDeposit
+		reqDeposit := uint64(0)
+		if req.ftokens != nil {
+			reqDeposit = req.ftokens.BaseTokens
+		}
+
+		if reqDeposit >= storageDeposit {
+			return 0
+		}
+		return storageDeposit - reqDeposit*/
 }
 
 func (ch *Chain) ResolveVMError(e *isc.UnresolvedVMError) *isc.VMError {

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -360,7 +360,11 @@ func (env *Solo) deployChain(
 
 	db, writeMutex, err := env.chainStateDatabaseManager.ChainStateKVStore(chainID)
 	require.NoError(env.T, err)
-	originAOMinSD := parameters.L1().Protocol.RentStructure.MinRent(originAO)
+
+	panic("refactor me: parameters.L1() / RentStructure")
+	originAOMinSD := uint64(0)
+	//originAOMinSD := parameters.L1().Protocol.RentStructure.MinRent(originAO)
+
 	store := indexedstore.New(state.NewStoreWithUniqueWriteMutex(db))
 	origin.InitChain(0, store, initParams, originAO.Amount-originAOMinSD)
 

--- a/packages/testutil/privtangle/privtangle.go
+++ b/packages/testutil/privtangle/privtangle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 
 	"github.com/iotaledger/iota.go/v3/nodeclient"
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/testutil/privtangle/privtangledefaults"
 	"github.com/iotaledger/wasp/packages/util"
@@ -526,17 +527,15 @@ func (pt *PrivTangle) logf(msg string, args ...interface{}) {
 	}
 }
 
-func (pt *PrivTangle) L1Config(i ...int) l2connection.Config {
+func (pt *PrivTangle) L1Config(i ...int) clients.L1Config {
 	nodeIndex := 0
 	if len(i) > 0 {
 		nodeIndex = i[0]
 	}
-	return l2connection.Config{
-		APIAddress:    fmt.Sprintf("http://localhost:%d", pt.NodePortRestAPI(nodeIndex)),
-		INXAddress:    fmt.Sprintf("localhost:%d", pt.NodePortINX(nodeIndex)),
-		FaucetAddress: fmt.Sprintf("http://localhost:%d", pt.NodePortFaucet(nodeIndex)),
-		FaucetKey:     pt.FaucetKeyPair,
-		UseRemotePoW:  false,
+
+	return clients.L1Config{
+		APIURL:    fmt.Sprintf("http://localhost:%d", pt.NodePortRestAPI(nodeIndex)),
+		FaucetURL: fmt.Sprintf("http://localhost:%d", pt.NodePortFaucet(nodeIndex)),
 	}
 }
 

--- a/packages/util/l1starter/l1starter.go
+++ b/packages/util/l1starter/l1starter.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"path"
 
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/packages/testutil/privtangle"
 	"github.com/iotaledger/wasp/packages/testutil/privtangle/privtangledefaults"
 )
 
 type L1Starter struct {
-	Config             l2connection.Config
+	Config             clients.L1Config
 	privtangleNumNodes int
 	Privtangle         *privtangle.PrivTangle
 }
@@ -19,21 +20,18 @@ type L1Starter struct {
 // New sets up the CLI flags relevant to L1/privtangle configuration in the given FlagSet.
 func New(l1flags, inxFlags *flag.FlagSet) *L1Starter {
 	s := &L1Starter{}
-	l1flags.StringVar(&s.Config.APIAddress, "layer1-api", "", "layer1 API address")
-	inxFlags.StringVar(&s.Config.INXAddress, "layer1-inx", "", "layer1 INX address")
-	l1flags.StringVar(&s.Config.FaucetAddress, "layer1-faucet", "", "layer1 faucet port")
-	l1flags.BoolVar(&s.Config.UseRemotePoW, "layer1-remote-pow", false, "use remote PoW (must be enabled on the Hornet node)")
+	l1flags.StringVar(&s.Config.APIURL, "layer1-api", "", "layer1 API address")
 	l1flags.IntVar(&s.privtangleNumNodes, "privtangle-num-nodes", 2, "number of hornet nodes to be spawned in the private tangle")
 	return s
 }
 
 func (s *L1Starter) PrivtangleEnabled() bool {
-	return s.Config.APIAddress == "" || s.Privtangle != nil
+	return s.Config.APIURL == "" || s.Privtangle != nil
 }
 
 // StartPrivtangleIfNecessary starts a private tangle, unless an L1 host was provided via cli flags
 func (s *L1Starter) StartPrivtangleIfNecessary(logfunc privtangle.LogFunc) {
-	if s.Config.APIAddress != "" {
+	if s.Config.APIURL != "" {
 		return
 	}
 	s.Privtangle = privtangle.Start(

--- a/packages/webapi/models/node.go
+++ b/packages/webapi/models/node.go
@@ -43,7 +43,7 @@ type L1Params struct {
 }
 
 func MapL1Params(l1 *parameters.L1Params) *L1Params {
-	params := &L1Params{
+	/*params := &L1Params{
 		// There are no limits on how big from a size perspective an essence can be, so it is just derived from 32KB - Message fields without payload = max size of the payload
 		MaxPayloadSize: l1.MaxPayloadSize,
 		Protocol: ProtocolParameters{
@@ -67,8 +67,8 @@ func MapL1Params(l1 *parameters.L1Params) *L1Params {
 			UseMetricPrefix: l1.BaseToken.UseMetricPrefix,
 		},
 	}
-
-	return params
+	*/
+	return nil
 }
 
 type VersionResponse struct {

--- a/sui-go/examples/event_pubsub/main.go
+++ b/sui-go/examples/event_pubsub/main.go
@@ -24,7 +24,7 @@ func main() {
 	if err != nil {
 		log.Panic(err)
 	}
-	err = suiclient.RequestFundsFromFaucet(sender.Address(), suiconn.TestnetFaucetURL)
+	err = suiclient.RequestFundsFromFaucet(context.Background(), sender.Address(), suiconn.TestnetFaucetURL)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/sui-go/suiclient/api_impl.go
+++ b/sui-go/suiclient/api_impl.go
@@ -1,6 +1,8 @@
 package suiclient
 
 import (
+	"context"
+
 	"github.com/iotaledger/wasp/sui-go/suiconn"
 	"github.com/iotaledger/wasp/sui-go/suisigner"
 )
@@ -36,7 +38,7 @@ func (i *Client) WithSignerAndFund(seed []byte, index int) (*Client, suisigner.S
 	default:
 		panic("not supported network")
 	}
-	err := RequestFundsFromFaucet(signer.Address(), faucetURL)
+	err := RequestFundsFromFaucet(context.Background(), signer.Address(), faucetURL)
 	if err != nil {
 		panic(err)
 	}

--- a/sui-go/suiclient/faucet.go
+++ b/sui-go/suiclient/faucet.go
@@ -2,6 +2,7 @@ package suiclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,9 +15,9 @@ import (
 
 // refer the implementation of `request_tokens_from_faucet()` in
 // https://github.com/MystenLabs/sui/blob/main/crates/sui-sdk/examples/utils.rs#L91
-func RequestFundsFromFaucet(address *sui.Address, faucetUrl string) error {
+func RequestFundsFromFaucet(ctx context.Context, address *sui.Address, faucetUrl string) error {
 	paramJson := fmt.Sprintf(`{"FixedAmountRequest":{"recipient":"%v"}}`, address)
-	request, err := http.NewRequest(http.MethodPost, faucetUrl, bytes.NewBuffer([]byte(paramJson)))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, faucetUrl, bytes.NewBuffer([]byte(paramJson)))
 	if err != nil {
 		return err
 	}

--- a/sui-go/suiclient/faucet_test.go
+++ b/sui-go/suiclient/faucet_test.go
@@ -1,6 +1,7 @@
 package suiclient_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/iotaledger/wasp/sui-go/suiclient"
@@ -11,17 +12,17 @@ import (
 )
 
 func TestRequestFundsFromFaucet_Devnet(t *testing.T) {
-	err := suiclient.RequestFundsFromFaucet(suisigner.TestAddress, suiconn.DevnetFaucetURL)
+	err := suiclient.RequestFundsFromFaucet(context.Background(), suisigner.TestAddress, suiconn.DevnetFaucetURL)
 	require.NoError(t, err)
 }
 
 func TestRequestFundsFromFaucet_Testnet(t *testing.T) {
-	err := suiclient.RequestFundsFromFaucet(suisigner.TestAddress, suiconn.TestnetFaucetURL)
+	err := suiclient.RequestFundsFromFaucet(context.Background(), suisigner.TestAddress, suiconn.TestnetFaucetURL)
 	require.NoError(t, err)
 }
 
 func TestRequestFundsFromFaucet_Localnet(t *testing.T) {
 	t.Skip("only run with local node is set up")
-	err := suiclient.RequestFundsFromFaucet(suisigner.TestAddress, suiconn.LocalnetFaucetURL)
+	err := suiclient.RequestFundsFromFaucet(context.Background(), suisigner.TestAddress, suiconn.LocalnetFaucetURL)
 	require.NoError(t, err)
 }

--- a/sui-go/suijsonrpc/balance.go
+++ b/sui-go/suijsonrpc/balance.go
@@ -1,7 +1,9 @@
 package suijsonrpc
 
+type CoinType string
+
 type Balance struct {
-	CoinType        string            `json:"coinType"`
+	CoinType        CoinType          `json:"coinType"`
 	CoinObjectCount uint64            `json:"coinObjectCount"`
 	TotalBalance    *BigInt           `json:"totalBalance"`
 	LockedBalance   map[BigInt]BigInt `json:"lockedBalance"` // FIXME the type may not be wrong

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net/http"
 	"os"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/iotaledger/hive.go/logger"
 	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/clients/apiextensions"
 	"github.com/iotaledger/wasp/clients/chainclient"
@@ -37,6 +39,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/origin"
+	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/testutil/testkey"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/util"
@@ -50,7 +53,7 @@ type Cluster struct {
 	Started           bool
 	DataPath          string
 	OriginatorKeyPair *cryptolib.KeyPair
-	l1                l2connection.Client
+	l1                clients.L1Client
 	waspCmds          []*waspCmd
 	t                 *testing.T
 	log               *logger.Logger
@@ -79,7 +82,7 @@ func New(name string, config *ClusterConfig, dataPath string, t *testing.T, log 
 		waspCmds:          make([]*waspCmd, len(config.Wasp)),
 		t:                 t,
 		log:               log,
-		l1:                l2connection.NewClient(config.L1, log),
+		l1:                clients.NewL1Client(config.L1),
 		DataPath:          dataPath,
 	}
 }
@@ -99,10 +102,10 @@ func (clu *Cluster) NewKeyPairWithFunds() (*cryptolib.KeyPair, *cryptolib.Addres
 }
 
 func (clu *Cluster) RequestFunds(addr *cryptolib.Address) error {
-	return clu.l1.RequestFunds(addr)
+	return clu.l1.RequestFunds(context.Background(), *addr)
 }
 
-func (clu *Cluster) L1Client() l2connection.Client {
+func (clu *Cluster) L1Client() clients.L1Client {
 	return clu.l1
 }
 
@@ -268,7 +271,7 @@ func (clu *Cluster) DeployChain(allPeers, committeeNodes []int, quorum uint16, s
 
 	chainID, err := apilib.DeployChain(
 		apilib.CreateChainParams{
-			Layer2Client:      clu.L1Client(),
+			Layer1Client:      clu.L1Client(),
 			CommitteeAPIHosts: chain.CommitteeAPIHosts(),
 			N:                 uint16(len(committeeNodes)),
 			T:                 quorum,
@@ -826,37 +829,26 @@ func (clu *Cluster) ActiveNodes() []int {
 	return nodes
 }
 
-func (clu *Cluster) PostTransaction(tx *iotago.Transaction) error {
-	_, err := clu.l1.PostTxAndWaitUntilConfirmation(tx)
-	return err
-}
-
 func (clu *Cluster) AddressBalances(addr *cryptolib.Address) *isc.Assets {
 	// get funds controlled by addr
-	outputMap, err := clu.l1.OutputMap(addr)
+
+	balances, err := clu.l1.GetAllBalances(context.Background(), addr.AsSuiAddress())
 	if err != nil {
-		fmt.Printf("[cluster] GetConfirmedOutputs error: %v\n", err)
+		log.Panicf("[cluster] failed to GetAllBalances for address[%v]", addr.Bech32(parameters.Bech32Hrp))
 		return nil
 	}
+
 	balance := isc.NewEmptyAssets()
-	for _, out := range outputMap {
-		panic("refactor me: transaction.AssetsFromOutput")
-		_ = out
-		//balance.Add(transaction.AssetsFromOutput(out))
+	for _, out := range balances {
+		panic("refactor me: AddressBalances (Fix isc.Assets to use BigInt)")
+
+		if out.CoinType == parameters.Token.CoinType {
+			//	balance.BaseTokens = out.TotalBalance
+		} else {
+			//	balance.NativeTokens = out
+		}
 	}
 
-	// if the address is an alias output, we also need to fetch the output itself and add that balance
-	// if aliasAddr, ok := addr.(*iotago.AliasAddress); ok { // TODO: is it still needed?
-	_, aliasOutput, err := clu.l1.GetAliasOutput(iotago.AliasID(*addr))
-	if err != nil {
-		fmt.Printf("[cluster] GetAliasOutput error: %v\n", err)
-		return nil
-	}
-
-	panic("refactor me: transaction.AssetsFromOutput")
-	_ = aliasOutput
-	//balance.Add(transaction.AssetsFromOutput(aliasOutput))
-	//}
 	return balance
 }
 
@@ -869,16 +861,12 @@ func (clu *Cluster) AssertAddressBalances(addr *cryptolib.Address, expected *isc
 	return clu.AddressBalances(addr).Equals(expected)
 }
 
-func (clu *Cluster) GetOutputs(addr *cryptolib.Address) (map[iotago.OutputID]iotago.Output, error) {
-	return clu.l1.OutputMap(addr)
-}
-
 func (clu *Cluster) MintL1NFT(immutableMetadata []byte, target *cryptolib.Address, issuerKeypair *cryptolib.KeyPair) (iotago.OutputID, *iotago.NFTOutput, error) {
-	outputsSet, err := clu.l1.OutputMap(issuerKeypair.Address())
+	panic("refactor me: transaction.NewMintNFTsTransaction")
+	/*outputsSet, err := clu.l1.OutputMap(issuerKeypair.Address())
 	if err != nil {
 		return iotago.OutputID{}, nil, err
 	}
-	panic("refactor me: transaction.NewMintNFTsTransaction")
 	var tx *iotago.Transaction
 	_ = outputsSet
 	err = errors.New("refactor me: MintL1NFT")
@@ -902,6 +890,6 @@ func (clu *Cluster) MintL1NFT(immutableMetadata []byte, target *cryptolib.Addres
 			return oID, oNFT, nil
 		}
 	}
-
+	*/
 	return iotago.OutputID{}, nil, fmt.Errorf("inconsistency: couldn't find newly minted NFT in tx")
 }

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"net/http"
 	"os"
@@ -834,7 +833,7 @@ func (clu *Cluster) AddressBalances(addr *cryptolib.Address) *isc.Assets {
 
 	balances, err := clu.l1.GetAllBalances(context.Background(), addr.AsSuiAddress())
 	if err != nil {
-		log.Panicf("[cluster] failed to GetAllBalances for address[%v]", addr.Bech32(parameters.Bech32Hrp))
+		clu.log.Panicf("[cluster] failed to GetAllBalances for address[%v]", addr.Bech32(parameters.Bech32Hrp))
 		return nil
 	}
 

--- a/tools/cluster/config.go
+++ b/tools/cluster/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/tools/cluster/templates"
 )
@@ -33,7 +34,7 @@ func (w *WaspConfig) WaspConfigTemplateParams(i int) templates.WaspConfigParams 
 
 type ClusterConfig struct {
 	Wasp []templates.WaspConfigParams
-	L1   l2connection.Config
+	L1   clients.L1Config
 }
 
 func DefaultWaspConfig() WaspConfig {
@@ -50,13 +51,12 @@ func ConfigExists(dataPath string) (bool, error) {
 	return fileExists(configPath(dataPath))
 }
 
-func NewConfig(waspConfig WaspConfig, l1Config l2connection.Config, modifyConfig ...templates.ModifyNodesConfigFn) *ClusterConfig {
+func NewConfig(waspConfig WaspConfig, l1Config clients.L1Config, modifyConfig ...templates.ModifyNodesConfigFn) *ClusterConfig {
 	nodesConfigs := make([]templates.WaspConfigParams, waspConfig.NumNodes)
 	for i := 0; i < waspConfig.NumNodes; i++ {
 		// generate template from waspconfigs
 		nodesConfigs[i] = waspConfig.WaspConfigTemplateParams(i)
 		// set L1 part of the template
-		nodesConfigs[i].L1INXAddress = l1Config.INXAddress
 		// modify the template if needed
 		if len(modifyConfig) > 0 && modifyConfig[0] != nil {
 			nodesConfigs[i] = modifyConfig[0](i, nodesConfigs[i])
@@ -161,7 +161,7 @@ func (c *ClusterConfig) PeeringPort(nodeIndex int) int {
 }
 
 func (c *ClusterConfig) L1APIAddress(nodeIndex int) string {
-	return c.L1.APIAddress
+	return c.L1.APIURL
 }
 
 func (c *ClusterConfig) ProfilingPort(nodeIndex int) int {

--- a/tools/cluster/wasp-cluster/main.go
+++ b/tools/cluster/wasp-cluster/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/hive.go/app/configuration"
 	appLogger "github.com/iotaledger/hive.go/app/logger"
 	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/packages/util/l1starter"
 	"github.com/iotaledger/wasp/tools/cluster"
 	"github.com/iotaledger/wasp/tools/cluster/templates"
@@ -98,7 +99,7 @@ func main() {
 			l1.Config,
 		)
 		clusterLogger := logger.NewLogger(cmdName)
-		l2connection.NewClient(clusterConfig.L1, clusterLogger) // indirectly initializes parameters.L1
+		clients.NewL1Client(clusterConfig.L1) // indirectly initializes parameters.L1
 		err := cluster.New(cmdName, clusterConfig, dataPath, nil, clusterLogger).InitDataPath(*templatesPath, *forceRemove)
 		check(err)
 
@@ -156,7 +157,7 @@ func main() {
 		}
 
 		clusterLogger := logger.NewLogger(cmdName)
-		l2connection.NewClient(clusterConfig.L1, clusterLogger) // indirectly initializes parameters.L1
+		clients.NewL1Client(clusterConfig.L1) // indirectly initializes parameters.L1
 		clu := cluster.New(cmdName, clusterConfig, dataPath, nil, clusterLogger)
 
 		if *disposable {

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -73,14 +73,14 @@ func initDeployCmd() *cobra.Command {
 				log.Fatalf("invalid chain name: %s, must be in slug format, only lowercase and hyphens, example: foo-bar", chainName)
 			}
 
-			l1Client := cliclients.L2Client()
+			l1Client := cliclients.L1Client()
 
 			govController := controllerAddrDefaultFallback(govControllerStr)
 
 			stateController := doDKG(node, peers, quorum)
 
 			par := apilib.CreateChainParams{
-				Layer2Client:         l1Client,
+				Layer1Client:         l1Client,
 				CommitteeAPIHosts:    config.NodeAPIURLs([]string{node}),
 				N:                    uint16(len(node)),
 				T:                    uint16(quorum),

--- a/tools/wasp-cli/cli/cliclients/clients.go
+++ b/tools/wasp-cli/cli/cliclients/clients.go
@@ -69,7 +69,7 @@ func L1Client() clients.L1Client {
 
 func ChainClient(waspClient *apiclient.APIClient, chainID isc.ChainID) *chainclient.Client {
 	return chainclient.New(
-		L2Client(),
+		L1Client(),
 		waspClient,
 		chainID,
 		wallet.Load(),

--- a/tools/wasp-cli/cli/cliclients/clients.go
+++ b/tools/wasp-cli/cli/cliclients/clients.go
@@ -3,14 +3,13 @@ package cliclients
 import (
 	"context"
 
+	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/clients/apiextensions"
 	"github.com/iotaledger/wasp/clients/chainclient"
 	"github.com/iotaledger/wasp/clients/iscmove"
 	"github.com/iotaledger/wasp/components/app"
 	"github.com/iotaledger/wasp/packages/isc"
-	"github.com/iotaledger/wasp/packages/l2connection"
-	"github.com/iotaledger/wasp/sui-go/suiclient"
 	"github.com/iotaledger/wasp/sui-go/suiconn"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/wallet"
@@ -53,20 +52,19 @@ func assertMatchingNodeVersion(name string, client *apiclient.APIClient) {
 	}
 }
 
-func L2Client() l2connection.Client {
-	log.Verbosef("using L1 API %s\n", config.L1APIAddress())
-
-	return iscmove.NewClient(
+func L2Client() clients.L2Client {
+	return clients.NewL2Client(
 		iscmove.Config{
-			APIURL:       suiconn.LocalnetEndpointURL,
-			FaucetURL:    suiconn.LocalnetFaucetURL,
-			WebsocketURL: suiconn.LocalnetWebsocketEndpointURL,
+			APIURL: suiconn.LocalnetEndpointURL,
 		},
 	)
 }
 
-func L1Client() *suiclient.Client {
-	return suiclient.New(suiconn.LocalnetEndpointURL)
+func L1Client() clients.L1Client {
+	return clients.NewL1Client(clients.L1Config{
+		APIURL:    suiconn.LocalnetEndpointURL,
+		FaucetURL: suiconn.LocalnetFaucetURL,
+	})
 }
 
 func ChainClient(waspClient *apiclient.APIClient, chainID isc.ChainID) *chainclient.Client {

--- a/tools/wasp-cli/wallet/info.go
+++ b/tools/wasp-cli/wallet/info.go
@@ -66,7 +66,7 @@ func initBalanceCmd() *cobra.Command {
 			log.Check(err)
 
 			model := &BalanceModel{
-				Address:      address.String(),
+				Address:      address.Bech32(parameters.Bech32Hrp),
 				AddressIndex: myWallet.AddressIndex(),
 				Tokens:       balance,
 			}

--- a/tools/wasp-cli/wallet/request-funds.go
+++ b/tools/wasp-cli/wallet/request-funds.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/wallet"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
@@ -17,10 +18,10 @@ func initRequestFundsCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			address := wallet.Load().Address()
-			log.Check(cliclients.L2Client().RequestFunds(context.Background(), *address))
+			log.Check(cliclients.L1Client().RequestFunds(context.Background(), *address))
 
 			model := &RequestFundsModel{
-				Address: address.String(),
+				Address: address.Bech32(parameters.Bech32Hrp),
 				Message: "success",
 			}
 


### PR DESCRIPTION
* Move L1/L2 client into `/clients`
* Generated interface for sui client (as L1Client)
* Embedded suiclient into our own "Extended" L1Client for additional methods (Health, RequestFunds)
* Added Token metadata as a constant value instead of L1() params 
* Brings back Bech32 
* Refactored Cluster environment
* Makes wasp and wasp-cli compilable
