### PR TITLE
chore: remove NativeTokenID / NFTID from core contracts

### DIFF
--- a/clients/apiextensions/assets.go
+++ b/clients/apiextensions/assets.go
@@ -6,37 +6,41 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 )
 
+// TODO: Discuss API structures once we have time for it.
+/**
+	Should we also just return a map of coins similar to isc.Assets, or should we make it "simpler" and keep the current structure of
+     * BaseTokens
+     * Coins []Coin
+*/
 func AssetsFromAPIResponse(assetsResponse *apiclient.AssetsResponse) (*isc.Assets, error) {
-	assets := isc.NewEmptyAssets()
-
-	baseTokens, err := iotago.DecodeUint64(assetsResponse.BaseTokens)
+	baseTokens, err := iotago.DecodeUint256(assetsResponse.BaseTokens)
 	if err != nil {
 		return nil, err
 	}
 
-	assets.BaseTokens = baseTokens
+	assets := isc.NewAssets(baseTokens)
+	/*
+		for _, nativeToken := range assetsResponse.NativeTokens {
+			nativeTokenIDHex, err2 := iotago.DecodeHex(nativeToken.Id)
+			if err2 != nil {
+				return nil, err2
+			}
 
-	for _, nativeToken := range assetsResponse.NativeTokens {
-		nativeTokenIDHex, err2 := iotago.DecodeHex(nativeToken.Id)
-		if err2 != nil {
-			return nil, err2
-		}
+			nativeTokenID, err2 := isc.NativeTokenIDFromBytes(nativeTokenIDHex)
+			if err2 != nil {
+				return nil, err2
+			}
 
-		nativeTokenID, err2 := isc.NativeTokenIDFromBytes(nativeTokenIDHex)
-		if err2 != nil {
-			return nil, err2
-		}
+			amount, err2 := iotago.DecodeUint256(nativeToken.Amount)
+			if err2 != nil {
+				return nil, err2
+			}
 
-		amount, err2 := iotago.DecodeUint256(nativeToken.Amount)
-		if err2 != nil {
-			return nil, err2
-		}
-
-		assets.NativeTokens = append(assets.NativeTokens, &iotago.NativeToken{
-			ID:     nativeTokenID,
-			Amount: amount,
-		})
-	}
+			assets.NativeTokens = append(assets.NativeTokens, &iotago.NativeToken{
+				ID:     nativeTokenID,
+				Amount: amount,
+			})
+		}*/
 
 	return assets, err
 }

--- a/packages/kv/codec/iotago.go
+++ b/packages/kv/codec/iotago.go
@@ -10,6 +10,7 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/sui-go/sui"
 )
 
 var Address = NewCodec(decodeAddress, encodeAddress)
@@ -55,23 +56,24 @@ func encodeTokenScheme(o iotago.TokenScheme) []byte {
 	return lo.Must(o.Serialize(serializer.DeSeriModeNoValidation, nil))
 }
 
-var NativeTokenID = NewCodec(decodeNativeTokenID, encodeNativeTokenID)
+var CoinType = NewCodec(decodeCoinType, encodeCoinType)
 
-func decodeNativeTokenID(b []byte) (ret isc.NativeTokenID, err error) {
+func decodeCoinType(b []byte) (ret isc.CoinType, err error) {
 	if len(b) != len(ret) {
 		return ret, fmt.Errorf("%T: bytes length must be %d", ret, len(ret))
 	}
 
-	return isc.NativeTokenIDFromBytes(b)
+	return isc.CoinTypeFromBytes(b)
 }
 
-func encodeNativeTokenID(nftID isc.NativeTokenID) []byte {
-	return nftID.Bytes()
+func encodeCoinType(coinType isc.CoinType) []byte {
+	return coinType.Bytes()
 }
 
-var NFTID = NewCodec(decodeNFTID, encodeNFTID)
+var ObjectID = NewCodec(decodeObjectID, encodeObjectID)
+var NFTID = ObjectID
 
-func decodeNFTID(b []byte) (ret isc.NFTID, err error) {
+func decodeObjectID(b []byte) (ret sui.ObjectID, err error) {
 	if len(b) != len(ret) {
 		return ret, fmt.Errorf("%T: bytes length must be %d", ret, len(ret))
 	}
@@ -79,6 +81,6 @@ func decodeNFTID(b []byte) (ret isc.NFTID, err error) {
 	return ret, nil
 }
 
-func encodeNFTID(nftID isc.NFTID) []byte {
-	return nftID[:]
+func encodeObjectID(objectID sui.ObjectID) []byte {
+	return objectID[:]
 }

--- a/packages/kv/codec/iotago.go
+++ b/packages/kv/codec/iotago.go
@@ -26,21 +26,6 @@ func encodeAddress(a *cryptolib.Address) []byte {
 	return a.Bytes()
 }
 
-var Output = NewCodec(decodeOutput, encodeOutput)
-
-func decodeOutput(b []byte) (iotago.Output, error) {
-	o, err := iotago.OutputSelector(uint32(b[0]))
-	if err != nil {
-		return nil, err
-	}
-	_, err = o.Deserialize(b, serializer.DeSeriModePerformValidation, nil)
-	return o, err
-}
-
-func encodeOutput(o iotago.Output) []byte {
-	return lo.Must(o.Serialize(serializer.DeSeriModeNoValidation, nil))
-}
-
 var TokenScheme = NewCodec(decodeTokenScheme, encodeTokenScheme)
 
 func decodeTokenScheme(b []byte) (iotago.TokenScheme, error) {

--- a/packages/kv/kvdecoder/kvdecoder.go
+++ b/packages/kv/kvdecoder/kvdecoder.go
@@ -301,7 +301,7 @@ func (p *kvdecoder) GetNativeTokenID(key kv.Key, def ...iotago.NativeTokenID) (i
 		}
 		return iotago.NativeTokenID{}, fmt.Errorf("GetNativeTokenID: mandatory parameter %q does not exist", key)
 	}
-	return codec.NativeTokenID.Decode(v)
+	return codec.CoinType.Decode(v)
 }
 
 func (p *kvdecoder) MustGetNativeTokenID(key kv.Key, def ...iotago.NativeTokenID) iotago.NativeTokenID {

--- a/packages/vm/core/accounts/foundries.go
+++ b/packages/vm/core/accounts/foundries.go
@@ -65,10 +65,10 @@ func (s *StateWriter) DeleteFoundryOutput(sn uint32) {
 }
 
 // GetFoundryOutput returns foundry output, its block number and output index
-func (s *StateReader) GetFoundryOutput(sn uint32, chainID isc.ChainID) (*iotago.FoundryOutput, iotago.OutputID) {
+func (s *StateReader) GetFoundryOutput(sn uint32, chainID isc.ChainID) (*iotago.FoundryOutput, sui.ObjectID) {
 	data := s.allFoundriesMapR().GetAt(codec.Uint32.Encode(sn))
 	if data == nil {
-		return nil, iotago.OutputID{}
+		return nil, sui.ObjectID{}
 	}
 	rec := mustFoundryOutputRecFromBytes(data)
 

--- a/packages/vm/core/accounts/impl.go
+++ b/packages/vm/core/accounts/impl.go
@@ -58,7 +58,7 @@ var Processor = Contract.Processor(nil,
 // this expects the origin amount minus SD
 func (s *StateWriter) SetInitialState(baseTokensOnAnchor uint64) {
 	// initial load with base tokens from origin anchor output exceeding minimum storage deposit assumption
-	s.CreditToAccount(CommonAccount(), isc.NewAssetsBaseTokensU64(baseTokensOnAnchor), isc.ChainID{})
+	s.CreditToAccount(CommonAccount(), isc.NewAssetsBaseTokens(baseTokensOnAnchor), isc.ChainID{})
 }
 
 // deposit is a function to deposit attached assets to the sender's chain account
@@ -368,7 +368,7 @@ func nativeTokenModifySupply(ctx isc.Sandbox, sn uint32, delta *big.Int, destroy
 		debitBaseTokensFromAllowance(ctx, uint64(-storageDepositAdjustment), ctx.ChainID())
 	case storageDepositAdjustment > 0:
 		// storage deposit is returned to the caller account
-		state.CreditToAccount(caller, isc.NewAssetsBaseTokensU64(uint64(storageDepositAdjustment)), ctx.ChainID())
+		state.CreditToAccount(caller, isc.NewAssetsBaseTokens(uint64(storageDepositAdjustment)), ctx.ChainID())
 	}
 	eventFoundryModified(ctx, sn)
 	return

--- a/packages/vm/core/accounts/impl_views.go
+++ b/packages/vm/core/accounts/impl_views.go
@@ -3,7 +3,6 @@ package accounts
 import (
 	"math/big"
 
-	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/isc/coreutil"
 	"github.com/iotaledger/wasp/packages/kv"
@@ -78,12 +77,13 @@ func viewAccountFoundries(ctx isc.SandboxView, optionalAgentID *isc.AgentID) map
 var errFoundryNotFound = coreerrors.Register("foundry not found").Create()
 
 // viewFoundryOutput takes serial number and returns corresponding foundry output in serialized form
-func viewFoundryOutput(ctx isc.SandboxView, sn uint32) iotago.Output {
+func viewFoundryOutput(ctx isc.SandboxView, sn uint32) sui.ObjectID {
 	ctx.Log().Debugf("accounts.viewFoundryOutput")
 	out, _ := NewStateReaderFromSandbox(ctx).GetFoundryOutput(sn, ctx.ChainID())
 	if out == nil {
 		panic(errFoundryNotFound)
 	}
+	// TODO: refactor me (FoundryOutput -> TreasuryCap -> Sui.ObjectID)
 	return out
 }
 

--- a/packages/vm/core/accounts/impl_views.go
+++ b/packages/vm/core/accounts/impl_views.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/vm/core/errors/coreerrors"
+	"github.com/iotaledger/wasp/sui-go/sui"
 )
 
 // viewBalance returns the balances of the account belonging to the AgentID
@@ -31,7 +32,7 @@ func viewBalanceBaseTokenEVM(ctx isc.SandboxView, optionalAgentID *isc.AgentID) 
 }
 
 // viewBalanceNativeToken returns the native token balance of the account belonging to the AgentID
-func viewBalanceNativeToken(ctx isc.SandboxView, optionalAgentID *isc.AgentID, nativeTokenID isc.NativeTokenID) *big.Int {
+func viewBalanceNativeToken(ctx isc.SandboxView, optionalAgentID *isc.AgentID, nativeTokenID isc.CoinType) *big.Int {
 	aid := coreutil.FromOptional(optionalAgentID, ctx.Caller())
 	return NewStateReaderFromSandbox(ctx).getNativeTokenAmount(
 		accountKey(aid, ctx.ChainID()),
@@ -52,11 +53,11 @@ func viewGetAccountNonce(ctx isc.SandboxView, optionalAgentID *isc.AgentID) uint
 }
 
 // viewGetNativeTokenIDRegistry returns all native token ID accounted in the chain
-func viewGetNativeTokenIDRegistry(ctx isc.SandboxView) []isc.NativeTokenID {
+func viewGetNativeTokenIDRegistry(ctx isc.SandboxView) []isc.CoinType {
 	ntMap := NewStateReaderFromSandbox(ctx).nativeTokenOutputMapR()
-	ret := make([]isc.NativeTokenID, 0, ntMap.Len())
+	ret := make([]isc.CoinType, 0, ntMap.Len())
 	ntMap.IterateKeys(func(b []byte) bool {
-		ntID := codec.NativeTokenID.MustDecode(b)
+		ntID := codec.CoinType.MustDecode(b)
 		ret = append(ret, ntID)
 		return true
 	})
@@ -87,7 +88,7 @@ func viewFoundryOutput(ctx isc.SandboxView, sn uint32) iotago.Output {
 }
 
 // viewAccountNFTs returns the NFTIDs of NFTs owned by an account
-func viewAccountNFTs(ctx isc.SandboxView, optionalAgentID *isc.AgentID) []isc.NFTID {
+func viewAccountNFTs(ctx isc.SandboxView, optionalAgentID *isc.AgentID) []sui.ObjectID {
 	ctx.Log().Debugf("accounts.viewAccountNFTs")
 	aid := coreutil.FromOptional(optionalAgentID, ctx.Caller())
 	return NewStateReaderFromSandbox(ctx).getAccountNFTs(aid)
@@ -98,18 +99,18 @@ func viewAccountNFTAmount(ctx isc.SandboxView, optionalAgentID *isc.AgentID) uin
 	return NewStateReaderFromSandbox(ctx).accountToNFTsMapR(aid).Len()
 }
 
-func viewAccountNFTsInCollection(ctx isc.SandboxView, optionalAgentID *isc.AgentID, collectionID isc.NFTID) []isc.NFTID {
+func viewAccountNFTsInCollection(ctx isc.SandboxView, optionalAgentID *isc.AgentID, collectionID sui.ObjectID) []sui.ObjectID {
 	aid := coreutil.FromOptional(optionalAgentID, ctx.Caller())
 	return NewStateReaderFromSandbox(ctx).getAccountNFTsInCollection(aid, collectionID)
 }
 
-func viewAccountNFTAmountInCollection(ctx isc.SandboxView, optionalAgentID *isc.AgentID, collectionID isc.NFTID) uint32 {
+func viewAccountNFTAmountInCollection(ctx isc.SandboxView, optionalAgentID *isc.AgentID, collectionID sui.ObjectID) uint32 {
 	aid := coreutil.FromOptional(optionalAgentID, ctx.Caller())
 	return NewStateReaderFromSandbox(ctx).nftsByCollectionMapR(aid, kv.Key(collectionID[:])).Len()
 }
 
 // viewNFTData returns the NFT data for a given NFTID
-func viewNFTData(ctx isc.SandboxView, nftID isc.NFTID) *isc.NFT {
+func viewNFTData(ctx isc.SandboxView, nftID sui.ObjectID) *isc.NFT {
 	ctx.Log().Debugf("accounts.viewNFTData")
 	data := NewStateReaderFromSandbox(ctx).GetNFTData(nftID)
 	if data == nil {

--- a/packages/vm/core/accounts/interface.go
+++ b/packages/vm/core/accounts/interface.go
@@ -80,7 +80,7 @@ var (
 	)
 	ViewBalanceNativeToken = coreutil.NewViewEP21(Contract, "balanceNativeToken",
 		coreutil.FieldWithCodecOptional(ParamAgentID, codec.AgentID),
-		coreutil.FieldWithCodec(ParamNativeTokenID, codec.NativeTokenID),
+		coreutil.FieldWithCodec(ParamNativeTokenID, codec.CoinType),
 		coreutil.FieldWithCodec(ParamBalance, codec.BigIntAbs),
 	)
 	ViewNativeToken = coreutil.NewViewEP11(Contract, "nativeToken",
@@ -267,11 +267,11 @@ func (OutputSerialNumberSet) Decode(r dict.Dict) (map[uint32]struct{}, error) {
 type OutputNativeTokenIDs struct{}
 
 func (OutputNativeTokenIDs) Encode(ids []isc.NativeTokenID) dict.Dict {
-	return codec.SliceToDictKeys(codec.NativeTokenID, ids)
+	return codec.SliceToDictKeys(codec.CoinType, ids)
 }
 
 func (OutputNativeTokenIDs) Decode(r dict.Dict) ([]isc.NativeTokenID, error) {
-	return codec.SliceFromDictKeys(codec.NativeTokenID, r)
+	return codec.SliceFromDictKeys(codec.CoinType, r)
 }
 
 type OutputFungibleTokens struct{}

--- a/packages/vm/core/accounts/interface.go
+++ b/packages/vm/core/accounts/interface.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/sui-go/sui"
 )
 
 var Contract = coreutil.NewContract(coreutil.CoreContractAccounts)
@@ -85,7 +86,7 @@ var (
 	)
 	ViewNativeToken = coreutil.NewViewEP11(Contract, "nativeToken",
 		coreutil.FieldWithCodec(ParamFoundrySN, codec.Uint32),
-		coreutil.FieldWithCodec(ParamFoundryOutputBin, codec.Output),
+		coreutil.FieldWithCodec(ParamFoundryOutputBin, codec.ObjectID), // TODO: refactor me (Output was removed and ObjectID used instead)
 	)
 
 	ViewGetAccountNonce = coreutil.NewViewEP11(Contract, "getAccountNonce",
@@ -204,7 +205,7 @@ func (e EPMintNFT) Message(
 	immutableMetadata []byte,
 	target isc.AgentID,
 	withdrawOnMint *bool,
-	collectionID *isc.NFTID,
+	collectionID *sui.ObjectID,
 ) isc.Message {
 	params := dict.Dict{
 		ParamNFTImmutableData: immutableMetadata,
@@ -219,13 +220,13 @@ func (e EPMintNFT) Message(
 	return e.EntryPointInfo.Message(params)
 }
 
-func (e EPMintNFT) WithHandler(f func(isc.Sandbox, []byte, isc.AgentID, bool, isc.NFTID) []byte) *coreutil.EntryPointHandler[isc.Sandbox] {
+func (e EPMintNFT) WithHandler(f func(isc.Sandbox, []byte, isc.AgentID, bool, sui.ObjectID) []byte) *coreutil.EntryPointHandler[isc.Sandbox] {
 	return e.EntryPointInfo.WithHandler(func(ctx isc.Sandbox) dict.Dict {
 		d := ctx.Params().Dict
 		immutableMetadata := lo.Must(codec.Bytes.Decode(d[ParamNFTImmutableData]))
 		target := lo.Must(codec.AgentID.Decode(d[ParamAgentID]))
 		withdraw := lo.Must(codec.Bool.Decode(d[ParamNFTWithdrawOnMint], false))
-		collID := lo.Must(codec.NFTID.Decode(d[ParamCollectionID], isc.NFTID{}))
+		collID := lo.Must(codec.NFTID.Decode(d[ParamCollectionID], sui.ObjectID{}))
 
 		mintID := f(ctx, immutableMetadata, target, withdraw, collID)
 		return dict.Dict{ParamMintID: mintID}
@@ -234,7 +235,7 @@ func (e EPMintNFT) WithHandler(f func(isc.Sandbox, []byte, isc.AgentID, bool, is
 
 type OutputNFTIDs struct{}
 
-func (OutputNFTIDs) Encode(nftIDs []isc.NFTID) dict.Dict {
+func (OutputNFTIDs) Encode(nftIDs []sui.ObjectID) dict.Dict {
 	// TODO: add pagination?
 	if len(nftIDs) > math.MaxUint16 {
 		panic("too many NFTs")
@@ -242,7 +243,7 @@ func (OutputNFTIDs) Encode(nftIDs []isc.NFTID) dict.Dict {
 	return codec.SliceToArray(codec.NFTID, nftIDs, ParamNFTIDs)
 }
 
-func (OutputNFTIDs) Decode(r dict.Dict) ([]isc.NFTID, error) {
+func (OutputNFTIDs) Decode(r dict.Dict) ([]sui.ObjectID, error) {
 	return codec.SliceFromArray(codec.NFTID, r, ParamNFTIDs)
 }
 
@@ -266,11 +267,11 @@ func (OutputSerialNumberSet) Decode(r dict.Dict) (map[uint32]struct{}, error) {
 
 type OutputNativeTokenIDs struct{}
 
-func (OutputNativeTokenIDs) Encode(ids []isc.NativeTokenID) dict.Dict {
+func (OutputNativeTokenIDs) Encode(ids []isc.CoinType) dict.Dict {
 	return codec.SliceToDictKeys(codec.CoinType, ids)
 }
 
-func (OutputNativeTokenIDs) Decode(r dict.Dict) ([]isc.NativeTokenID, error) {
+func (OutputNativeTokenIDs) Decode(r dict.Dict) ([]isc.CoinType, error) {
 	return codec.SliceFromDictKeys(codec.CoinType, r)
 }
 

--- a/packages/vm/core/accounts/internal.go
+++ b/packages/vm/core/accounts/internal.go
@@ -184,12 +184,12 @@ func debitBaseTokensFromAllowance(ctx isc.Sandbox, amount uint64, chainID isc.Ch
 	if amount == 0 {
 		return
 	}
-	storageDepositAssets := isc.NewAssetsBaseTokensU64(amount)
+	storageDepositAssets := isc.NewAssetsBaseTokens(amount)
 	ctx.TransferAllowedFunds(CommonAccount(), storageDepositAssets)
 	NewStateWriterFromSandbox(ctx).DebitFromAccount(CommonAccount(), storageDepositAssets, chainID)
 }
 
-func (s *StateWriter) UpdateLatestOutputID(anchorTxID sui.ObjectID, blockIndex uint32) []isc.NFTID {
+func (s *StateWriter) UpdateLatestOutputID(anchorTxID sui.ObjectID, blockIndex uint32) []sui.ObjectID {
 	s.updateNativeTokenOutputIDs(anchorTxID)
 	s.updateFoundryOutputIDs(anchorTxID)
 	s.updateNFTOutputIDs(anchorTxID)

--- a/packages/vm/core/accounts/internal_test.go
+++ b/packages/vm/core/accounts/internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/migrations/allmigrations"
+	"github.com/iotaledger/wasp/sui-go/sui"
 )
 
 func TestAccounts(t *testing.T) {
@@ -41,7 +42,7 @@ func knownAgentID(b byte, h uint32) isc.AgentID {
 	return isc.NewContractAgentID(chainID, isc.Hname(h))
 }
 
-var dummyAssetID = [isc.NativeTokenIDLength]byte{1, 2, 3}
+var dummyAssetID = isc.CoinType("foo")
 
 func checkLedgerT(t *testing.T, v isc.SchemaVersion, state dict.Dict) *isc.Assets {
 	require.NotPanics(t, func() {
@@ -320,7 +321,7 @@ func testTransferNFTs(t *testing.T, v isc.SchemaVersion) {
 
 	agentID1 := isc.NewRandomAgentID()
 	NFT1 := &isc.NFT{
-		ID:       isc.NFTID{123},
+		ID:       sui.ObjectID{123},
 		Issuer:   cryptolib.NewRandomAddress(),
 		Metadata: []byte("foobar"),
 	}
@@ -357,7 +358,7 @@ func testTransferNFTs(t *testing.T, v isc.SchemaVersion) {
 	agentID2 := isc.NewRandomAgentID()
 
 	// cannot move an NFT that is not owned
-	require.Error(t, accounts.NewStateWriter(v, state).MoveBetweenAccounts(agentID1, agentID2, isc.NewEmptyAssets().AddNFTs(isc.NFTID{111}), isc.ChainID{}))
+	require.Error(t, accounts.NewStateWriter(v, state).MoveBetweenAccounts(agentID1, agentID2, isc.NewEmptyAssets().AddNFTs(sui.ObjectID{111}), isc.ChainID{}))
 
 	// moves successfully when the NFT is owned
 	err := accounts.NewStateWriter(v, state).MoveBetweenAccounts(agentID1, agentID2, isc.NewEmptyAssets().AddNFTs(NFT1.ID), isc.ChainID{})
@@ -381,7 +382,7 @@ func testCreditDebitNFT1(t *testing.T, v isc.SchemaVersion) {
 
 	agentID1 := knownAgentID(1, 2)
 	nft := isc.NFT{
-		ID:       isc.NFTID{123},
+		ID:       sui.ObjectID{123},
 		Issuer:   cryptolib.NewRandomAddress(),
 		Metadata: []byte("foobar"),
 	}

--- a/packages/vm/core/accounts/nativetokenoutputs.go
+++ b/packages/vm/core/accounts/nativetokenoutputs.go
@@ -45,8 +45,8 @@ func (s *StateWriter) updateNativeTokenOutputIDs(anchorTxID sui.ObjectID) {
 	newNativeTokens.Erase()
 }
 
-func (s *StateWriter) DeleteNativeTokenOutput(nativeTokenID isc.NativeTokenID) {
-	s.nativeTokenOutputMap().DelAt(nativeTokenID[:])
+func (s *StateWriter) DeleteNativeTokenOutput(nativeTokenID isc.CoinType) {
+	s.nativeTokenOutputMap().DelAt(nativeTokenID.Bytes())
 }
 
 func (s *StateReader) GetNativeTokenOutput(nativeTokenID sui.ObjectID, chainID isc.ChainID) (*iotago.BasicOutput, iotago.OutputID) {

--- a/packages/vm/core/accounts/nativetokens.go
+++ b/packages/vm/core/accounts/nativetokens.go
@@ -21,7 +21,7 @@ func (s *StateWriter) nativeTokensMap(accountKey kv.Key) *collections.Map {
 	return collections.NewMap(s.state, nativeTokensMapKey(accountKey))
 }
 
-func (s *StateReader) getNativeTokenAmount(accountKey kv.Key, tokenID isc.NativeTokenID) *big.Int {
+func (s *StateReader) getNativeTokenAmount(accountKey kv.Key, tokenID isc.CoinType) *big.Int {
 	r := new(big.Int)
 	b := s.nativeTokensMapR(accountKey).GetAt(tokenID.Bytes())
 	if len(b) > 0 {
@@ -30,7 +30,7 @@ func (s *StateReader) getNativeTokenAmount(accountKey kv.Key, tokenID isc.Native
 	return r
 }
 
-func (s *StateWriter) setNativeTokenAmount(accountKey kv.Key, tokenID isc.NativeTokenID, n *big.Int) {
+func (s *StateWriter) setNativeTokenAmount(accountKey kv.Key, tokenID isc.CoinType, n *big.Int) {
 	if n.Sign() == 0 {
 		s.nativeTokensMap(accountKey).DelAt(tokenID.Bytes())
 	} else {
@@ -38,18 +38,19 @@ func (s *StateWriter) setNativeTokenAmount(accountKey kv.Key, tokenID isc.Native
 	}
 }
 
-func (s *StateReader) GetNativeTokenBalance(agentID isc.AgentID, nativeTokenID isc.NativeTokenID, chainID isc.ChainID) *big.Int {
+func (s *StateReader) GetNativeTokenBalance(agentID isc.AgentID, nativeTokenID isc.CoinType, chainID isc.ChainID) *big.Int {
 	return s.getNativeTokenAmount(accountKey(agentID, chainID), nativeTokenID)
 }
 
-func (s *StateReader) GetNativeTokenBalanceTotal(nativeTokenID isc.NativeTokenID) *big.Int {
+func (s *StateReader) GetNativeTokenBalanceTotal(nativeTokenID isc.CoinType) *big.Int {
 	return s.getNativeTokenAmount(L2TotalsAccount, nativeTokenID)
 }
 
-func (s *StateReader) GetNativeTokens(agentID isc.AgentID, chainID isc.ChainID) isc.NativeTokens {
-	ret := isc.NativeTokens{}
+func (s *StateReader) GetNativeTokens(agentID isc.AgentID, chainID isc.ChainID) isc.CoinBalances {
+	ret := isc.CoinBalances{}
 	s.nativeTokensMapR(accountKey(agentID, chainID)).Iterate(func(idBytes []byte, val []byte) bool {
-		ret = append(ret, &isc.NativeToken{
+		// TODO: Adapt to map structure
+		ret = append(ret, &isc.Coin{
 			CoinType: isc.MustNativeTokenIDFromBytes(idBytes),
 			Amount:   new(big.Int).SetBytes(val),
 		})

--- a/packages/vm/core/accounts/nftmint.go
+++ b/packages/vm/core/accounts/nftmint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/wasp/packages/util/rwutil"
 	"github.com/iotaledger/wasp/packages/vm/core/errors/coreerrors"
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
+	"github.com/iotaledger/wasp/sui-go/sui"
 )
 
 type mintedNFTRecord struct {
@@ -90,7 +91,7 @@ func mintParams(
 	immutableMetadata []byte,
 	targetAgentID isc.AgentID,
 	withdrawOnMint bool,
-	collectionID isc.NFTID,
+	collectionID sui.ObjectID{},
 ) mintParameters {
 	chainAddress := ctx.ChainID().AsAddress()
 	ret := mintParameters{
@@ -141,7 +142,7 @@ func mintNFT(
 	immutableMetadata []byte,
 	target isc.AgentID,
 	withdrawOnMint bool,
-	collectionID isc.NFTID,
+	collectionID sui.ObjectID{},
 ) []byte {
 	params := mintParams(ctx, immutableMetadata, target, withdrawOnMint, collectionID)
 
@@ -204,7 +205,7 @@ func mintNFT(
 	return mintID(ctx.StateAnchor().StateIndex+1, positionInMintedList)
 }
 
-func viewNFTIDbyMintID(ctx isc.SandboxView, internalMintID []byte) (ret isc.NFTID) {
+func viewNFTIDbyMintID(ctx isc.SandboxView, internalMintID []byte) (ret sui.ObjectID) {
 	state := NewStateReaderFromSandbox(ctx)
 	b := state.mintIDMapR().GetAt(internalMintID)
 	copy(ret[:], b)

--- a/packages/vm/core/accounts/nftoutputs.go
+++ b/packages/vm/core/accounts/nftoutputs.go
@@ -41,11 +41,11 @@ func (s *StateWriter) updateNFTOutputIDs(anchorTxID sui.ObjectID) {
 	newNFTs.Erase()
 }
 
-func (s *StateWriter) DeleteNFTOutput(nftID isc.NFTID) {
+func (s *StateWriter) DeleteNFTOutput(nftID sui.ObjectID) {
 	s.nftOutputMap().DelAt(nftID[:])
 }
 
-func (s *StateReader) GetNFTOutput(nftID isc.NFTID) (*iotago.NFTOutput, iotago.OutputID) {
+func (s *StateReader) GetNFTOutput(nftID sui.ObjectID) (*iotago.NFTOutput, iotago.OutputID) {
 	data := s.nftOutputMapR().GetAt(nftID[:])
 	if data == nil {
 		return nil, iotago.OutputID{}

--- a/packages/vm/core/evm/interface.go
+++ b/packages/vm/core/evm/interface.go
@@ -48,7 +48,7 @@ var (
 	)
 
 	ViewGetERC20ExternalNativeTokenAddress = coreutil.NewViewEP11(Contract, evmnames.ViewGetERC20ExternalNativeTokenAddress,
-		coreutil.FieldWithCodec(FieldNativeTokenID, codec.NativeTokenID),
+		coreutil.FieldWithCodec(FieldNativeTokenID, codec.CoinType),
 		coreutil.FieldWithCodecOptional(FieldResult, codec.EthereumAddress),
 	)
 

--- a/packages/vm/vmimpl/internal.go
+++ b/packages/vm/vmimpl/internal.go
@@ -56,7 +56,7 @@ func (reqctx *requestContext) debitFromAccountFullDecimals(agentID isc.AgentID, 
 }
 
 // debitNFTFromAccount removes a NFT from an account.
-func (reqctx *requestContext) debitNFTFromAccount(agentID isc.AgentID, nftID isc.NFTID, gasBurn bool) {
+func (reqctx *requestContext) debitNFTFromAccount(agentID isc.AgentID, nftID sui.ObjectID, gasBurn bool) {
 	reqctx.accountsStateWriter(gasBurn).DebitNFTFromAccount(agentID, nftID, reqctx.ChainID())
 }
 
@@ -88,7 +88,7 @@ func (reqctx *requestContext) HasEnoughForAllowance(agentID isc.AgentID, allowan
 	return ret
 }
 
-func (reqctx *requestContext) GetNativeTokenBalance(agentID isc.AgentID, nativeTokenID sui.ObjectID) *big.Int {
+func (reqctx *requestContext) GetNativeTokenBalance(agentID isc.AgentID, nativeTokenID isc.CoinType) *big.Int {
 	var ret *big.Int
 	reqctx.callAccounts(func(s *accounts.StateWriter) {
 		ret = s.GetNativeTokenBalance(agentID, nativeTokenID, reqctx.ChainID())
@@ -96,7 +96,7 @@ func (reqctx *requestContext) GetNativeTokenBalance(agentID isc.AgentID, nativeT
 	return ret
 }
 
-func (reqctx *requestContext) GetNativeTokenBalanceTotal(nativeTokenID sui.ObjectID) *big.Int {
+func (reqctx *requestContext) GetNativeTokenBalanceTotal(nativeTokenID isc.CoinType) *big.Int {
 	var ret *big.Int
 	reqctx.callAccounts(func(s *accounts.StateWriter) {
 		ret = s.GetNativeTokenBalanceTotal(nativeTokenID)
@@ -104,22 +104,22 @@ func (reqctx *requestContext) GetNativeTokenBalanceTotal(nativeTokenID sui.Objec
 	return ret
 }
 
-func (reqctx *requestContext) GetNativeTokens(agentID isc.AgentID) isc.NativeTokens {
-	var ret isc.NativeTokens
+func (reqctx *requestContext) GetNativeTokens(agentID isc.AgentID) []isc.CoinType {
+	var ret []isc.CoinType
 	reqctx.callAccounts(func(s *accounts.StateWriter) {
 		ret = s.GetNativeTokens(agentID, reqctx.ChainID())
 	})
 	return ret
 }
 
-func (reqctx *requestContext) GetAccountNFTs(agentID isc.AgentID) (ret []isc.NFTID) {
+func (reqctx *requestContext) GetAccountNFTs(agentID isc.AgentID) (ret []sui.ObjectID) {
 	reqctx.callAccounts(func(s *accounts.StateWriter) {
 		ret = s.GetAccountNFTs(agentID)
 	})
 	return ret
 }
 
-func (reqctx *requestContext) GetNFTData(nftID isc.NFTID) (ret *isc.NFT) {
+func (reqctx *requestContext) GetNFTData(nftID sui.ObjectID) (ret *isc.NFT) {
 	reqctx.callAccounts(func(s *accounts.StateWriter) {
 		ret = s.GetNFTData(nftID)
 	})

--- a/tools/wasp-cli/util/types.go
+++ b/tools/wasp-cli/util/types.go
@@ -188,7 +188,7 @@ func ValueToString(vtype string, v []byte) string {
 	case "string":
 		return fmt.Sprintf("%q", string(v))
 	case "tokenid":
-		tid, err := codec.NativeTokenID.Decode(v)
+		tid, err := codec.CoinType.Decode(v)
 		log.Check(err)
 		return tid.String()
 	case "uint8":


### PR DESCRIPTION
# Description of change

This removes the NativeTokenID / NFTID from the codec, but introduces CoinType and ObjectID instead.
`accounts` was refactored to use new arg/return types. Logic remains untouched.
 