### PR TITLE
Fix GetAnchorFromObjectID() and Add AssetsBagPlaceCoinAmount()

### DIFF
--- a/clients/iscmove/iscmoveclient/client_allowance.go
+++ b/clients/iscmove/iscmoveclient/client_allowance.go
@@ -31,11 +31,11 @@ func (c *Client) AllowanceNew(
 	pt := ptb.Finish()
 
 	if len(gasPayments) == 0 {
-		coins, err := c.GetCoinObjsForTargetAmount(ctx, signer.Address(), gasBudget)
+		coinPage, err := c.GetCoins(ctx, suiclient.GetCoinsRequest{Owner: signer.Address()})
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch GasPayment object: %w", err)
 		}
-		gasPayments = coins.CoinRefs()
+		gasPayments = []*sui.ObjectRef{coinPage.Data[0].Ref()}
 	}
 
 	tx := sui.NewProgrammable(
@@ -93,11 +93,11 @@ func (c *Client) AllowanceWithCoinBalance(
 	pt := ptb.Finish()
 
 	if len(gasPayments) == 0 {
-		coins, err := c.GetCoinObjsForTargetAmount(ctx, signer.Address(), gasBudget)
+		coinPage, err := c.GetCoins(ctx, suiclient.GetCoinsRequest{Owner: signer.Address()})
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch GasPayment object: %w", err)
 		}
-		gasPayments = coins.CoinRefs()
+		gasPayments = []*sui.ObjectRef{coinPage.Data[0].Ref()}
 	}
 
 	tx := sui.NewProgrammable(
@@ -153,11 +153,11 @@ func (c *Client) AllowanceDestroy(
 	pt := ptb.Finish()
 
 	if len(gasPayments) == 0 {
-		coins, err := c.GetCoinObjsForTargetAmount(ctx, signer.Address(), gasBudget)
+		coinPage, err := c.GetCoins(ctx, suiclient.GetCoinsRequest{Owner: signer.Address()})
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch GasPayment object: %w", err)
 		}
-		gasPayments = coins.CoinRefs()
+		gasPayments = []*sui.ObjectRef{coinPage.Data[0].Ref()}
 	}
 
 	tx := sui.NewProgrammable(

--- a/clients/iscmove/iscmoveclient/client_assets_bag_test.go
+++ b/clients/iscmove/iscmoveclient/client_assets_bag_test.go
@@ -51,7 +51,7 @@ func TestAssetsBagNewAndDestroyEmpty(t *testing.T) {
 	require.Error(t, err, "not found")
 }
 
-func TestAssetsBagAddItems(t *testing.T) {
+func TestAssetsBagPlaceCoin(t *testing.T) {
 	cryptolibSigner := newSignerWithFunds(t, testSeed, 0)
 	client := newLocalnetClient()
 
@@ -88,6 +88,53 @@ func TestAssetsBagAddItems(t *testing.T) {
 		assetsBagMainRef,
 		coinInfo.Ref,
 		testCointype,
+		nil,
+		suiclient.DefaultGasPrice,
+		suiclient.DefaultGasBudget,
+		false,
+	)
+	require.NoError(t, err)
+}
+
+func TestAssetsBagPlaceCoinAmount(t *testing.T) {
+	cryptolibSigner := newSignerWithFunds(t, testSeed, 0)
+	client := newLocalnetClient()
+
+	txnResponse, err := client.AssetsBagNew(
+		context.Background(),
+		cryptolibSigner,
+		l1starter.ISCPackageID(),
+		nil,
+		suiclient.DefaultGasPrice,
+		suiclient.DefaultGasBudget,
+		false,
+	)
+	require.NoError(t, err)
+	assetsBagMainRef, err := txnResponse.GetCreatedObjectInfo(iscmove.AssetsBagModuleName, iscmove.AssetsBagObjectName)
+	require.NoError(t, err)
+
+	_, coinInfo := buildDeployMintTestcoin(t, client, cryptolibSigner)
+	getCoinRef, err := client.GetObject(
+		context.Background(),
+		suiclient.GetObjectRequest{
+			ObjectID: coinInfo.Ref.ObjectID,
+			Options:  &suijsonrpc.SuiObjectDataOptions{ShowType: true},
+		},
+	)
+	require.NoError(t, err)
+
+	coinResource, err := sui.NewResourceType(*getCoinRef.Data.Type)
+	require.NoError(t, err)
+	testCointype := suijsonrpc.CoinType(coinResource.SubType.String())
+
+	_, err = client.AssetsBagPlaceCoinAmount(
+		context.Background(),
+		cryptolibSigner,
+		l1starter.ISCPackageID(),
+		assetsBagMainRef,
+		coinInfo.Ref,
+		testCointype,
+		10,
 		nil,
 		suiclient.DefaultGasPrice,
 		suiclient.DefaultGasBudget,

--- a/clients/iscmove/iscmoveclient/client_request.go
+++ b/clients/iscmove/iscmoveclient/client_request.go
@@ -52,11 +52,11 @@ func (c *Client) CreateAndSendRequest(
 	pt := ptb.Finish()
 
 	if len(gasPayments) == 0 {
-		coins, err := c.GetCoinObjsForTargetAmount(ctx, signer.Address(), gasBudget)
+		coinPage, err := c.GetCoins(ctx, suiclient.GetCoinsRequest{Owner: signer.Address()})
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch GasPayment object: %w", err)
 		}
-		gasPayments = coins.CoinRefs()
+		gasPayments = []*sui.ObjectRef{coinPage.Data[0].Ref()}
 	}
 
 	tx := sui.NewProgrammable(

--- a/clients/iscmove/iscmoveclient/feed_test.go
+++ b/clients/iscmove/iscmoveclient/feed_test.go
@@ -99,8 +99,10 @@ func TestRequestsFeed(t *testing.T) {
 	require.Len(t, ownedReqs, 1)
 	require.Equal(t, *requestRef.ObjectID, ownedReqs[0].ID)
 
+	txb := sui.NewProgrammableTransactionBuilder()
 	_, err = client.ReceiveRequestAndTransition(
 		context.Background(),
+		txb,
 		chainOwner,
 		l1starter.ISCPackageID(),
 		&anchor.ObjectRef,

--- a/sui-go/suiclient/extend_calls.go
+++ b/sui-go/suiclient/extend_calls.go
@@ -96,6 +96,27 @@ func (c *Client) PublishContract(
 	return txnResponse, packageID, nil
 }
 
+func (c *Client) UpdateObjectRef(
+	ctx context.Context,
+	ref *sui.ObjectRef,
+) (*sui.ObjectRef, error) {
+	res, err := c.GetObject(
+		context.Background(),
+		GetObjectRequest{
+			ObjectID: ref.ObjectID,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the object of ObjectRef: %w", err)
+	}
+
+	return &sui.ObjectRef{
+		ObjectID: res.Data.ObjectID,
+		Version:  res.Data.Version.Uint64(),
+		Digest:   res.Data.Digest,
+	}, nil
+}
+
 func (c *Client) MintToken(
 	ctx context.Context,
 	signer suisigner.Signer,


### PR DESCRIPTION
GetAnchorFromObjectID() cant get the balances of AssetsBag. And using `GetCoins` to replace `GetCoinObjsForTargetAmount()` for explicitly assigning the gas coin.

Add `AssetsBagPlaceCoinAmount` to split a coin and place the split the coin into AssetsBag.

Add `UpdateObjectRef()` to easily update ObjectRef