### PR TITLE
fix: Fixed BCS codec for RefWithObject, AssetsBag and ObjectRef

### DIFF
--- a/clients/iscmove/isc.go
+++ b/clients/iscmove/isc.go
@@ -1,8 +1,6 @@
 package iscmove
 
 import (
-	"io"
-
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/sui-go/sui"
@@ -67,14 +65,6 @@ func (rwo *RefWithObject[any]) Hash() hashing.HashValue {
 	return res
 }
 
-func (rwo *RefWithObject[any]) Read(r io.Reader) error {
-	return nil // TODO implement
-}
-
-func (rwo *RefWithObject[any]) Write(w io.Writer) error {
-	return nil // TODO implement
-}
-
 // AssetsBag is the BCS equivalent for the move type AssetsBag
 type AssetsBag struct {
 	ID   sui.ObjectID
@@ -102,14 +92,6 @@ func (a *Anchor) GetStateIndex() uint32 {
 
 func (a *Anchor) Equals(b *Anchor) bool {
 	return a.ID.Equals(b.ID)
-}
-
-func (a *Anchor) Read(r io.Reader) error {
-	return nil // TODO implement
-}
-
-func (a *Anchor) Write(w io.Writer) error {
-	return nil // TODO implement
 }
 
 type Receipt struct {

--- a/clients/iscmove/isc_test.go
+++ b/clients/iscmove/isc_test.go
@@ -1,0 +1,39 @@
+package iscmove_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/iotaledger/wasp/clients/iscmove"
+	"github.com/iotaledger/wasp/packages/util/bcs"
+	"github.com/iotaledger/wasp/sui-go/sui"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIscCodec(t *testing.T) {
+	type ExampleObj struct {
+		A int
+	}
+
+	bcs.TestCodec(t, iscmove.RefWithObject[ExampleObj]{
+		ObjectRef: *sui.RandomObjectRef(),
+		Object:    &ExampleObj{A: 42},
+	})
+
+	anchor := iscmove.RandomAnchor()
+
+	var digest sui.Base58
+	_, err := rand.Read(digest)
+	require.NoError(t, err)
+
+	anchorRef := iscmove.RefWithObject[iscmove.Anchor]{
+		ObjectRef: sui.ObjectRef{
+			ObjectID: &anchor.ID,
+			Version:  13,
+			Digest:   &digest,
+		},
+		Object: &anchor,
+	}
+
+	bcs.TestCodec(t, anchorRef)
+}

--- a/sui-go/sui/base_types.go
+++ b/sui-go/sui/base_types.go
@@ -3,7 +3,6 @@ package sui
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 	"math/rand"
 
 	"github.com/iotaledger/wasp/sui-go/sui/serialization"
@@ -89,14 +88,6 @@ func RandomObjectRef() *ObjectRef {
 		Version:  rand.Uint64(),
 		Digest:   RandomDigest(),
 	}
-}
-
-func (or *ObjectRef) Read(r io.Reader) error {
-	return nil // TODO implement
-}
-
-func (or *ObjectRef) Write(w io.Writer) error {
-	return nil // TODO implement
 }
 
 func (or *ObjectRef) Equals(other *ObjectRef) bool {


### PR DESCRIPTION
Fixed BCS codec for RefWithObject, AssetsBag and ObjectRef