### PR TITLE
fix: Fixed cryptolib serialization writing redundant length info into stream

### DIFF
--- a/packages/cryptolib/address.go
+++ b/packages/cryptolib/address.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/iotaledger/wasp/packages/util/rwutil"
 	"github.com/iotaledger/wasp/sui-go/sui"
 )
 
@@ -98,16 +97,13 @@ func (a *Address) Clone() *Address {
 }
 
 func (a *Address) Read(r io.Reader) error {
-	rr := rwutil.NewReader(r)
-	address := rr.ReadBytes()
-	copy(a[:], address)
-	return rr.Err
+	_, err := r.Read(a[:])
+	return err
 }
 
 func (a *Address) Write(w io.Writer) error {
-	ww := rwutil.NewWriter(w)
-	ww.WriteBytes(a[:])
-	return ww.Err
+	_, err := w.Write(a[:])
+	return err
 }
 
 func (a Address) MarshalJSON() ([]byte, error) {
@@ -148,9 +144,4 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	}
 
 	return err
-}
-
-// FIXME may need to be pointer
-func (a Address) MarshalBCS() ([]byte, error) {
-	return a[:], nil
 }

--- a/packages/cryptolib/address_test.go
+++ b/packages/cryptolib/address_test.go
@@ -7,6 +7,7 @@ import (
 
 	oldbcs "github.com/fardream/go-bcs/bcs"
 	"github.com/iotaledger/wasp/packages/util/bcs"
+	"github.com/iotaledger/wasp/packages/util/rwutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,8 +95,10 @@ func TestAddressBCSCodec(t *testing.T) {
 	addr := NewRandomAddress()
 	encOld := oldbcs.MustMarshal(addr)
 	encNew := bcs.MustMarshal(&addr)
+	encRwutil := rwutil.NewBytesWriter().Write(addr).Bytes()
 
 	require.Equal(t, len(encOld), len(encNew), addr)
 	require.Equal(t, encOld, encNew, addr)
+	require.Equal(t, encNew, encRwutil, addr)
 	require.Equal(t, len(encNew), len(addr), encNew)
 }

--- a/packages/cryptolib/address_test.go
+++ b/packages/cryptolib/address_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"testing"
 
+	oldbcs "github.com/fardream/go-bcs/bcs"
+	"github.com/iotaledger/wasp/packages/util/bcs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -86,4 +88,14 @@ func TestAddressFromIota(t *testing.T) {
 
 		require.True(t, addrIota1.Equal(addrIota2))
 	*/
+}
+
+func TestAddressBCSCodec(t *testing.T) {
+	addr := NewRandomAddress()
+	encOld := oldbcs.MustMarshal(addr)
+	encNew := bcs.MustMarshal(&addr)
+
+	require.Equal(t, len(encOld), len(encNew), addr)
+	require.Equal(t, encOld, encNew, addr)
+	require.Equal(t, len(encNew), len(addr), encNew)
 }


### PR DESCRIPTION
Fixed cryptolib serialization writing redundant length info into stream