### PR TITLE
fix: Fixed bcs.Decode() has error returned, although by design it shouldnt

### DIFF
--- a/packages/util/bcs/README.md
+++ b/packages/util/bcs/README.md
@@ -582,11 +582,15 @@ To decode an interface it either must be registered an enum, have registred cust
 Unlike from function `Marshal`(), method `Encode`() accepts both value and pointer. But passing by value will force encoder to copy value to make it addressable to support `MarshalBCS`() method with pointer receiver. It will also not work properly when interface is passed by value, because value is unpacked and packed again as `any` thus information about type of initial interface will be lost.
 So it is better to pass a pointer always when it is easy to do.
 
-#### Serialization of arrays of intergers is optimized
+#### Serialization of byte arrays is optimized
 
-If elements of array are of integer type, and they dont have any customization specified for them (except of `"bytes=N"`), such array will be serialized using optimized version of code. Especially this is noticeable for byte arrays.
+Arrays of bytes, whose elements does not have any customizations, are directly copied into/from the stream.
 
-#### Caching of type parsing
+#### Serialization of arrays of intergers is NOT yet optimized
+
+If elements of array are of integer type, and they dont have any customization specified for them (except of `"type=T"`), serialization of such array could be optimized to avoid redudant calls for each array element. But this not done specifically to keep code simple while it is maturing.
+
+#### Type parsing is cached
 
 Upon serialization the types are checked for the presense of customizations. This make take significant time.
 To improve that, the type information is stored in cache.

--- a/packages/util/bcs/decode.go
+++ b/packages/util/bcs/decode.go
@@ -790,16 +790,16 @@ func (d *Decoder) handleErrorf(format string, args ...interface{}) error {
 	return d.r.Err
 }
 
-func Decode[V any](dec *Decoder) (V, error) {
+func Decode[V any](dec *Decoder) V {
 	var v V
-	err := dec.Decode(&v)
+	dec.Decode(&v)
 
-	return v, err
+	return v
 }
 
 func MustDecode[V any](dec *Decoder) V {
-	v, err := Decode[V](dec)
-	if err != nil {
+	v := Decode[V](dec)
+	if err := dec.Err(); err != nil {
 		panic(fmt.Errorf("failed to decode object of type %T: %w", v, err))
 	}
 
@@ -808,7 +808,8 @@ func MustDecode[V any](dec *Decoder) V {
 
 func UnmarshalStream[T any](r io.Reader) (T, error) {
 	dec := NewDecoder(r)
-	return Decode[T](dec)
+	v := Decode[T](dec)
+	return v, dec.Err()
 }
 
 func MustUnmarshalStream[T any](r io.Reader) T {

--- a/packages/vm/core/blocklog/interface.go
+++ b/packages/vm/core/blocklog/interface.go
@@ -95,8 +95,8 @@ func (OutputRequestReceipt) Decode(r []byte) (*RequestReceipt, error) {
 	rr := bytes.NewReader(r)
 	dec := bcs.NewDecoder(rr)
 
-	blockIndex, _ := bcs.Decode[uint32](dec)
-	reqIndex, _ := bcs.Decode[uint16](dec)
+	blockIndex := bcs.Decode[uint32](dec)
+	reqIndex := bcs.Decode[uint16](dec)
 
 	if dec.Err() != nil {
 		return nil, dec.Err()


### PR DESCRIPTION
Fixed bcs.Decode() has error returned, although by design it shouldnt