### PR TITLE
fix: Fixed encoding of big values of compact ints in BCS

### DIFF
--- a/packages/util/bcs/encode.go
+++ b/packages/util/bcs/encode.go
@@ -273,13 +273,13 @@ func (e *Encoder) encodeValue(v reflect.Value, typeOptionsFromTag *TypeOptions, 
 		e.w.WriteBool(v.Bool())
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		if typeOptions.IsCompactInt {
-			e.w.WriteSize32(int(v.Int()))
+			e.WriteCompactUint(uint64(v.Int()))
 		} else {
 			err = e.encodeInt(v, typeOptions.UnderlayingType)
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		if typeOptions.IsCompactInt {
-			e.w.WriteSize32(int(v.Uint()))
+			e.WriteCompactUint(v.Uint())
 		} else {
 			err = e.encodeUint(v, typeOptions.UnderlayingType)
 		}

--- a/packages/util/bcs/struct_test.go
+++ b/packages/util/bcs/struct_test.go
@@ -359,6 +359,10 @@ type CompactInt struct {
 	A int64 `bcs:"compact"`
 }
 
+type CompactUint struct {
+	A uint64 `bcs:"compact"`
+}
+
 type IntWithLessBytes struct {
 	A int64 `bcs:"type=i16"`
 }
@@ -380,6 +384,12 @@ type IntWithMoreBytesAndOtherUnsigned struct {
 func TestIntTypeConversion(t *testing.T) {
 	bcs.TestCodecAndBytes(t, CompactInt{A: 1}, []byte{0x1})
 	bcs.TestCodecAndBytes(t, CompactInt{A: 70000}, []byte{0xf0, 0xa2, 0x4})
+	bcs.TestCodecAndBytes(t, CompactInt{A: math.MaxInt64}, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f})
+	bcs.TestCodecAndBytes(t, CompactInt{A: math.MinInt64}, []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x1})
+
+	bcs.TestCodecAndBytes(t, CompactUint{A: 1}, []byte{0x1})
+	bcs.TestCodecAndBytes(t, CompactUint{A: 70000}, []byte{0xf0, 0xa2, 0x4})
+	bcs.TestCodecAndBytes(t, CompactUint{A: math.MaxUint64}, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1})
 
 	bcs.TestCodecAndBytes(t, IntWithLessBytes{A: 42}, []byte{42, 0})
 	bcs.TestCodecAndBytes(t, IntWithMoreBytes{A: 42}, []byte{42, 0, 0, 0})


### PR DESCRIPTION
Fixed encoding of big values of compact ints in BCS