### PR TITLE
chare: StateAnchor fixes, test refactoring cmt_log/cons

### DIFF
--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -30,7 +30,7 @@ type CreateChainParams struct {
 	Textout              io.Writer
 	Prefix               string
 	StateMetadata        transaction.StateMetadata
-	GasCoinObjectID      *iotago.ObjectID `bcs:"optional"`
+	GasCoinObjectID      *iotago.ObjectID
 	GovernanceController *cryptolib.Address
 	PackageID            iotago.PackageID
 }

--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -30,6 +30,7 @@ type CreateChainParams struct {
 	Textout              io.Writer
 	Prefix               string
 	StateMetadata        transaction.StateMetadata
+	GasCoinObjectID      *iotago.ObjectID `bcs:"optional"`
 	GovernanceController *cryptolib.Address
 	PackageID            iotago.PackageID
 }
@@ -54,7 +55,7 @@ func DeployChain(ctx context.Context, par CreateChainParams, stateControllerAddr
 	}
 
 	var gasPayments []*iotago.ObjectRef
-	if par.StateMetadata.GasCoinObjectID != nil {
+	if par.GasCoinObjectID != nil {
 		resGetObj, err := par.Layer1Client.GetObject(ctx, iotaclient.GetObjectRequest{ObjectID: par.StateMetadata.GasCoinObjectID})
 		if err != nil {
 			return isc.ChainID{}, err

--- a/packages/chain/cmt_log/cmt_log_test.go
+++ b/packages/chain/cmt_log/cmt_log_test.go
@@ -73,7 +73,7 @@ func testCmtLogBasic(t *testing.T, n, f int) {
 	gpaTC.PrintAllStatusStrings("Initial", t.Logf)
 	//
 	// Provide first alias output. Consensus should be sent now.
-	ao1 := randomAliasOutputWithID(*aliasRef.ObjectID, committeeAddress, 1)
+	ao1 := randomAnchorWithID(*aliasRef.ObjectID, committeeAddress, 1)
 	t.Logf("AO1=%v", ao1)
 	gpaTC.WithInputs(inputAliasOutputConfirmed(gpaNodes, ao1)).RunAll()
 	gpaTC.PrintAllStatusStrings("After AO1Recv", t.Logf)
@@ -84,7 +84,7 @@ func testCmtLogBasic(t *testing.T, n, f int) {
 	}
 	//
 	// Consensus results received (consumed ao1, produced ao2).
-	ao2 := randomAliasOutputWithID(*aliasRef.ObjectID, committeeAddress, 2)
+	ao2 := randomAnchorWithID(*aliasRef.ObjectID, committeeAddress, 2)
 	t.Logf("AO2=%v", ao2)
 	gpaTC.WithInputs(inputConsensusOutput(gpaNodes, cons1, ao2)).RunAll()
 	gpaTC.PrintAllStatusStrings("After gpaMsgsAO2Cons", t.Logf)
@@ -127,7 +127,7 @@ func inputConsensusOutput(gpaNodes map[gpa.NodeID]gpa.GPA, consReq *cmt_log.Outp
 	return inputs
 }
 
-func randomAliasOutputWithID(anchorID iotago.ObjectID, stateAddress *cryptolib.Address, stateIndex uint32) *isc.StateAnchor {
+func randomAnchorWithID(anchorID iotago.ObjectID, stateAddress *cryptolib.Address, stateIndex uint32) *isc.StateAnchor {
 	anchor := iscmovetest.RandomAnchor(iscmovetest.RandomAnchorOption{StateMetadata: &[]byte{}, StateIndex: &stateIndex, ID: &anchorID})
 	stateAnchor := isc.NewStateAnchor(
 		&iscmove.AnchorWithRef{

--- a/packages/chain/cmt_log/cmt_log_test.go
+++ b/packages/chain/cmt_log/cmt_log_test.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/clients/iota-go/iotago"
+	"github.com/iotaledger/wasp/clients/iota-go/iotago/iotatest"
+	"github.com/iotaledger/wasp/clients/iscmove"
+	"github.com/iotaledger/wasp/clients/iscmove/iscmovetest"
 	"github.com/iotaledger/wasp/packages/chain/cmt_log"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/gpa"
@@ -42,9 +45,8 @@ func testCmtLogBasic(t *testing.T, n, f int) {
 	defer log.Sync()
 	//
 	// Chain identifiers.
-	aliasID := testiotago.RandAliasID()
-	chainID := isc.ChainIDFromAliasID(aliasID)
-	governor := cryptolib.NewKeyPair()
+	aliasRef := iotatest.RandomObjectRef()
+	chainID := isc.ChainIDFromObjectID(*aliasRef.ObjectID)
 	//
 	// Node identities.
 	_, peerIdentities := testpeers.SetupKeys(uint16(n))
@@ -71,7 +73,7 @@ func testCmtLogBasic(t *testing.T, n, f int) {
 	gpaTC.PrintAllStatusStrings("Initial", t.Logf)
 	//
 	// Provide first alias output. Consensus should be sent now.
-	ao1 := randomAliasOutputWithID(aliasID, governor.Address(), committeeAddress, 1)
+	ao1 := randomAliasOutputWithID(*aliasRef.ObjectID, committeeAddress, 1)
 	t.Logf("AO1=%v", ao1)
 	gpaTC.WithInputs(inputAliasOutputConfirmed(gpaNodes, ao1)).RunAll()
 	gpaTC.PrintAllStatusStrings("After AO1Recv", t.Logf)
@@ -82,7 +84,7 @@ func testCmtLogBasic(t *testing.T, n, f int) {
 	}
 	//
 	// Consensus results received (consumed ao1, produced ao2).
-	ao2 := randomAliasOutputWithID(aliasID, governor.Address(), committeeAddress, 2)
+	ao2 := randomAliasOutputWithID(*aliasRef.ObjectID, committeeAddress, 2)
 	t.Logf("AO2=%v", ao2)
 	gpaTC.WithInputs(inputConsensusOutput(gpaNodes, cons1, ao2)).RunAll()
 	gpaTC.PrintAllStatusStrings("After gpaMsgsAO2Cons", t.Logf)
@@ -120,21 +122,19 @@ func inputAliasOutputConfirmed(gpaNodes map[gpa.NodeID]gpa.GPA, ao *isc.StateAnc
 func inputConsensusOutput(gpaNodes map[gpa.NodeID]gpa.GPA, consReq *cmt_log.Output, nextAO *isc.StateAnchor) map[gpa.NodeID]gpa.Input {
 	inputs := map[gpa.NodeID]gpa.Input{}
 	for n := range gpaNodes {
-		inputs[n] = cmt_log.NewInputConsensusOutputDone(consReq.GetLogIndex(), consReq.GetBaseAliasOutput().ID, consReq.GetBaseAliasOutput().ID, nextAO)
+		inputs[n] = cmt_log.NewInputConsensusOutputDone(consReq.GetLogIndex(), *consReq.GetBaseAliasOutput().GetObjectID(), nextAO.GetObjectRef())
 	}
 	return inputs
 }
 
-func randomAliasOutputWithID(aliasID iotago.AliasID, governorAddress, stateAddress *cryptolib.Address, stateIndex uint32) *isc.StateAnchor {
-	outputID := testiotago.RandOutputID()
-	aliasOutput := &iotago.AliasOutput{
-		AliasID:       aliasID,
-		StateIndex:    stateIndex,
-		StateMetadata: []byte{},
-		Conditions: iotago.UnlockConditions{
-			&iotago.StateControllerAddressUnlockCondition{Address: stateAddress.AsIotagoAddress()},
-			&iotago.GovernorAddressUnlockCondition{Address: governorAddress.AsIotagoAddress()},
-		},
-	}
-	return isc.NewAliasOutputWithID(aliasOutput, outputID)
+func randomAliasOutputWithID(anchorID iotago.ObjectID, stateAddress *cryptolib.Address, stateIndex uint32) *isc.StateAnchor {
+	anchor := iscmovetest.RandomAnchor(iscmovetest.RandomAnchorOption{StateMetadata: &[]byte{}, StateIndex: &stateIndex, ID: &anchorID})
+	stateAnchor := isc.NewStateAnchor(
+		&iscmove.AnchorWithRef{
+			Object:    &anchor,
+			ObjectRef: *iotatest.RandomObjectRef(),
+			Owner:     stateAddress.AsIotaAddress(),
+		}, *cryptolib.NewRandomAddress().AsIotaAddress())
+
+	return &stateAnchor
 }

--- a/packages/chain/cons/bp/batch_proposal_test.go
+++ b/packages/chain/cons/bp/batch_proposal_test.go
@@ -47,7 +47,8 @@ func TestBatchProposal1Serialization(t *testing.T) {
 			Digest:   &digest,
 		},
 		Object: &anchor,
-	}, cryptolib.NewEmptyAddress(), *iotatest.RandomAddress())
+		Owner:  cryptolib.NewRandomAddress().AsIotaAddress(),
+	}, *iotatest.RandomAddress())
 
 	coinRef := iotatest.RandomObjectRef()
 

--- a/packages/chain/cons/cons.go
+++ b/packages/chain/cons/cons.go
@@ -625,8 +625,8 @@ func (c *consImpl) uponVMOutputReceived(vmResult *vm.VMTaskResult, aggregatedPro
 
 	if vmResult.RotationAddress != nil {
 		// Rotation by the Self-Governed Committee.
-		decidedAnchorRef := vmResult.Task.Anchor.Anchor().ObjectRef
-		rotationTX, err := vmtxbuilder.NewRotationTransaction(&decidedAnchorRef, vmResult.RotationAddress.AsIotaAddress())
+		decidedAnchorRef := vmResult.Task.Anchor.GetObjectRef()
+		rotationTX, err := vmtxbuilder.NewRotationTransaction(decidedAnchorRef, vmResult.RotationAddress.AsIotaAddress())
 		if err != nil {
 			c.log.Warnf("Cannot create rotation TX, failed to make TX essence: %w", err)
 			c.output.Status = Skipped

--- a/packages/chain/cons/cons.go
+++ b/packages/chain/cons/cons.go
@@ -63,6 +63,7 @@ import (
 	"github.com/iotaledger/wasp/clients/iota-go/iotasigner"
 
 	"github.com/iotaledger/hive.go/logger"
+
 	"github.com/iotaledger/wasp/packages/chain/cons/bp"
 	"github.com/iotaledger/wasp/packages/chain/dss"
 	"github.com/iotaledger/wasp/packages/cryptolib"
@@ -593,11 +594,11 @@ func (c *consImpl) uponVMInputsReceived(aggregatedProposals *bp.AggregatedBatchP
 	// TODO: chainState state.State is not used for now. That's because VM takes it form the store by itself.
 	// The decided base alias output can be different from that we have proposed!
 	decidedBaseAliasOutput := aggregatedProposals.DecidedBaseAliasOutput()
+	stateAnchor := isc.NewStateAnchor(decidedBaseAliasOutput.Anchor(), decidedBaseAliasOutput.ISCPackage())
+
 	c.output.NeedVMResult = &vm.VMTask{
-		Processors: c.processorCache,
-		Anchor: &isc.StateAnchor{
-			Anchor: decidedBaseAliasOutput.Anchor,
-		},
+		Processors:           c.processorCache,
+		Anchor:               &stateAnchor,
 		Store:                c.chainStore,
 		Requests:             aggregatedProposals.OrderedRequests(requests, *randomness),
 		Timestamp:            aggregatedProposals.AggregatedTime(),
@@ -624,7 +625,7 @@ func (c *consImpl) uponVMOutputReceived(vmResult *vm.VMTaskResult, aggregatedPro
 
 	if vmResult.RotationAddress != nil {
 		// Rotation by the Self-Governed Committee.
-		decidedAnchorRef := vmResult.Task.Anchor.Anchor.ObjectRef
+		decidedAnchorRef := vmResult.Task.Anchor.Anchor().ObjectRef
 		rotationTX, err := vmtxbuilder.NewRotationTransaction(&decidedAnchorRef, vmResult.RotationAddress.AsIotaAddress())
 		if err != nil {
 			c.log.Warnf("Cannot create rotation TX, failed to make TX essence: %w", err)

--- a/packages/chain/cons/cons_gr/gr_test.go
+++ b/packages/chain/cons/cons_gr/gr_test.go
@@ -5,7 +5,6 @@ package cons_gr_test
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"sync"
 	"testing"
@@ -42,7 +41,6 @@ import (
 )
 
 func TestGrBasic(t *testing.T) {
-	flag.Parse()
 	l1starter.TestInSingleTestFunc(t)
 
 	type test struct {

--- a/packages/chain/cons/cons_gr/gr_test.go
+++ b/packages/chain/cons/cons_gr/gr_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/logger"
+
 	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/clients/iota-go/iotaclient"
 	"github.com/iotaledger/wasp/clients/iota-go/iotaconn"
@@ -187,7 +188,7 @@ func testGrBasic(t *testing.T, n, f int, reliable bool) {
 type anchorKey = string
 
 func anchorKeyFromAnchor(anchor *isc.StateAnchor) anchorKey {
-	return anchor.Anchor.ObjectRef.String()
+	return anchor.Anchor().ObjectRef.String()
 }
 
 func anchorKeyFromAnchorRef(objectRef *iotago.ObjectRef) anchorKey {

--- a/packages/chain/cons/cons_gr/gr_test.go
+++ b/packages/chain/cons/cons_gr/gr_test.go
@@ -63,6 +63,8 @@ func TestGrBasic(t *testing.T) {
 		)
 	}
 
+	t.Parallel()
+
 	for _, tst := range tests {
 		t.Run(
 			fmt.Sprintf("N=%v,F=%v,Reliable=%v", tst.n, tst.f, tst.reliable),

--- a/packages/chain/cons/cons_gr/gr_test.go
+++ b/packages/chain/cons/cons_gr/gr_test.go
@@ -192,7 +192,7 @@ func testGrBasic(t *testing.T, n, f int, reliable bool) {
 type anchorKey = string
 
 func anchorKeyFromAnchor(anchor *isc.StateAnchor) anchorKey {
-	return anchor.Anchor().ObjectRef.String()
+	return anchor.GetObjectRef().String()
 }
 
 func anchorKeyFromAnchorRef(objectRef *iotago.ObjectRef) anchorKey {

--- a/packages/chain/cons/cons_test.go
+++ b/packages/chain/cons/cons_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/logger"
+
 	"github.com/iotaledger/wasp/clients/iota-go/iotago"
 	"github.com/iotaledger/wasp/clients/iota-go/iotago/iotatest"
 	"github.com/iotaledger/wasp/clients/iota-go/iotajsonrpc"
@@ -89,9 +90,9 @@ func testConsBasic(t *testing.T, n, f int) {
 	ao0 := &ao0x
 
 	reqs := []isc.Request{
-		RandomOnLedgerDepositRequest(ao0.Owner),
-		RandomOnLedgerDepositRequest(ao0.Owner),
-		RandomOnLedgerDepositRequest(ao0.Owner),
+		RandomOnLedgerDepositRequest(ao0.Owner()),
+		RandomOnLedgerDepositRequest(ao0.Owner()),
+		RandomOnLedgerDepositRequest(ao0.Owner()),
 	}
 	reqRefs := isc.RequestRefsFromRequests(reqs)
 

--- a/packages/chain/cons/cons_test.go
+++ b/packages/chain/cons/cons_test.go
@@ -732,6 +732,7 @@ func RandomOnLedgerDepositRequest(senders ...*cryptolib.Address) isc.OnLedgerReq
 			Allowance: iscmove.Assets{Coins: iscmove.CoinBalances{iotajsonrpc.IotaCoinType: 10000}},
 			GasBudget: 100000,
 		},
+		Owner: sender.AsIotaAddress(),
 	}
 	onReq, err := isc.OnLedgerFromRequest(&req, sender)
 	if err != nil {

--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
 	"github.com/iotaledger/hive.go/logger"
+
 	"github.com/iotaledger/wasp/clients/iota-go/iotasigner"
 	"github.com/iotaledger/wasp/packages/chain/chainmanager"
 	"github.com/iotaledger/wasp/packages/chain/cmt_log"
@@ -680,7 +681,7 @@ func (cni *chainNodeImpl) handleAliasOutput(ctx context.Context, aliasOutput isc
 	cni.stateTrackerCnf.TrackAliasOutput(&aliasOutput, true)
 	cni.stateTrackerAct.TrackAliasOutput(&aliasOutput, false) // ACT state will be equal to CNF or ahead of it.
 	outMsgs := cni.chainMgr.Input(
-		chainmanager.NewInputAliasOutputConfirmed(aliasOutput.Owner, &aliasOutput),
+		chainmanager.NewInputAliasOutputConfirmed(aliasOutput.Owner(), &aliasOutput),
 	)
 	cni.sendMessages(outMsgs)
 	cni.handleChainMgrOutput(ctx, cni.chainMgr.Output())

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_block_factory.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_block_factory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
+
 	"github.com/iotaledger/wasp/clients/iota-go/iotago"
 	"github.com/iotaledger/wasp/clients/iscmove"
 	"github.com/iotaledger/wasp/clients/iscmove/iscmovetest"
@@ -197,12 +198,12 @@ func (bfT *BlockFactory) GetNextBlock(
 
 	consumedAnchor := bfT.GetAnchor(commitment)
 	newAnchor := *consumedAnchor
-	consumedMetadata, err := transaction.StateMetadataFromBytes(consumedAnchor.Anchor.Object.StateMetadata)
+	consumedMetadata, err := transaction.StateMetadataFromBytes(consumedAnchor.Anchor().Object.StateMetadata)
 	require.NoError(bfT.t, err)
 	consumedMetadata.L1Commitment, err = state.NewL1CommitmentFromBytes(newCommitment.Bytes())
 	require.NoError(bfT.t, err)
-	newAnchor.Anchor.Object.StateIndex = newAnchor.Anchor.Object.StateIndex + 1
-	bfT.anchorData[newCommitment.BlockHash()] = *newAnchor.Anchor
+	newAnchor.Anchor().Object.StateIndex = newAnchor.Anchor().Object.StateIndex + 1
+	bfT.anchorData[newCommitment.BlockHash()] = *newAnchor.Anchor()
 
 	return block
 }
@@ -222,9 +223,7 @@ func (bfT *BlockFactory) GetAnchor(commitment *state.L1Commitment) *isc.StateAnc
 	anchor, ok := bfT.anchorData[commitment.BlockHash()]
 	require.True(bfT.t, ok)
 
-	return &isc.StateAnchor{
-		Anchor:     &anchor,
-		Owner:      nil,                               //FIXME
-		ISCPackage: *iotago.MustAddressFromHex("0x0"), //FIXME,
-	}
+	stateAnchor := isc.NewStateAnchor(&anchor, *iotago.MustAddressFromHex("0x0")) //FIXME,
+
+	return &stateAnchor
 }

--- a/packages/isc/isctest/random.go
+++ b/packages/isc/isctest/random.go
@@ -18,8 +18,9 @@ func RandomStateAnchorWithStateMetadata(metadata *transaction.StateMetadata) isc
 	anchorRef := iscmove.RefWithObject[iscmove.Anchor]{
 		ObjectRef: *iotatest.RandomObjectRef(),
 		Object:    &anchor,
+		Owner:     cryptolib.NewRandomAddress().AsIotaAddress(),
 	}
-	return isc.NewStateAnchor(&anchorRef, cryptolib.NewRandomAddress(), *iotatest.RandomAddress())
+	return isc.NewStateAnchor(&anchorRef, *iotatest.RandomAddress())
 }
 
 func RandomStateAnchor() isc.StateAnchor {
@@ -27,8 +28,9 @@ func RandomStateAnchor() isc.StateAnchor {
 	anchorRef := iscmove.RefWithObject[iscmove.Anchor]{
 		ObjectRef: *iotatest.RandomObjectRef(),
 		Object:    &anchor,
+		Owner:     cryptolib.NewRandomAddress().AsIotaAddress(),
 	}
-	return isc.NewStateAnchor(&anchorRef, cryptolib.NewRandomAddress(), *iotatest.RandomAddress())
+	return isc.NewStateAnchor(&anchorRef, *iotatest.RandomAddress())
 }
 
 // RandomChainID creates a random chain ID. Used for testing only

--- a/packages/isc/sandbox_interface.go
+++ b/packages/isc/sandbox_interface.go
@@ -360,9 +360,8 @@ type Gas interface {
 
 // StateAnchor contains properties of the anchor request/transaction in the current context
 type StateAnchor struct {
-	Anchor     *iscmove.AnchorWithRef
-	Owner      *cryptolib.Address
-	ISCPackage iotago.Address
+	anchor     *iscmove.AnchorWithRef
+	iscPackage iotago.Address
 }
 
 // Every time changing the L1 state of the Anchor object, the nodes should create
@@ -372,38 +371,48 @@ type StateAnchor struct {
 // * RotationTransaction
 func NewStateAnchor(
 	anchor *iscmove.AnchorWithRef,
-	owner *cryptolib.Address,
 	iscPackage iotago.Address,
 ) StateAnchor {
 	return StateAnchor{
-		Anchor:     anchor,
-		Owner:      owner,
-		ISCPackage: iscPackage,
+		anchor:     anchor,
+		iscPackage: iscPackage,
 	}
 }
 
+func (s *StateAnchor) ISCPackage() iotago.Address {
+	return s.iscPackage
+}
+
+func (s StateAnchor) Anchor() *iscmove.AnchorWithRef {
+	return s.anchor
+}
+
+func (s StateAnchor) Owner() *cryptolib.Address {
+	return cryptolib.NewAddressFromIota(s.anchor.Owner)
+}
+
 func (s StateAnchor) GetObjectRef() *iotago.ObjectRef {
-	return &s.Anchor.ObjectRef
+	return &s.anchor.ObjectRef
 }
 
 func (s StateAnchor) GetObjectID() *iotago.ObjectID {
-	return s.Anchor.ObjectID
+	return s.anchor.ObjectID
 }
 
 func (s StateAnchor) GetStateMetadata() []byte {
-	return s.Anchor.Object.StateMetadata
+	return s.anchor.Object.StateMetadata
 }
 
 func (s StateAnchor) GetStateIndex() uint32 {
-	return s.Anchor.Object.StateIndex
+	return s.anchor.Object.StateIndex
 }
 
 func (s StateAnchor) ChainID() ChainID {
-	return ChainIDFromObjectID(*s.Anchor.ObjectID)
+	return ChainIDFromObjectID(*s.anchor.ObjectID)
 }
 
 func (s StateAnchor) Hash() hashing.HashValue {
-	return s.Anchor.Hash()
+	return s.anchor.Hash()
 }
 
 func (s StateAnchor) Equals(input *StateAnchor) bool {
@@ -411,7 +420,7 @@ func (s StateAnchor) Equals(input *StateAnchor) bool {
 		return false
 	}
 
-	return iscmove.AnchorWithRefEquals(*s.Anchor, *input.Anchor)
+	return iscmove.AnchorWithRefEquals(*s.anchor, *input.Anchor())
 }
 
 type SendOptions struct {

--- a/packages/isc/sandbox_interface.go
+++ b/packages/isc/sandbox_interface.go
@@ -373,10 +373,6 @@ func NewStateAnchor(
 	anchor *iscmove.AnchorWithRef,
 	iscPackage iotago.Address,
 ) StateAnchor {
-	if anchor.Owner == nil {
-		// TODO: Review if this is a hack or a way to go.
-		anchor.Owner = owner.AsIotaAddress()
-	}
 	return StateAnchor{
 		anchor:     anchor,
 		iscPackage: iscPackage,

--- a/packages/isc/sandbox_interface.go
+++ b/packages/isc/sandbox_interface.go
@@ -379,6 +379,36 @@ func NewStateAnchor(
 	}
 }
 
+func (s *StateAnchor) MarshalBCS(e *bcs.Encoder) error {
+	err := e.Encode(s.anchor)
+	if err != nil {
+		return err
+	}
+
+	err = e.Encode(s.iscPackage)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *StateAnchor) UnmarshalBCS(d *bcs.Decoder) error {
+	s.anchor = nil
+	err := d.Decode(&s.anchor)
+	if err != nil {
+		return err
+	}
+
+	s.iscPackage = iotago.Address{}
+	err = d.Decode(&s.iscPackage)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *StateAnchor) ISCPackage() iotago.Address {
 	return s.iscPackage
 }

--- a/packages/nodeconn/chain.go
+++ b/packages/nodeconn/chain.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotaledger/wasp/packages/util/bcs"
 
 	"github.com/iotaledger/hive.go/logger"
+
 	"github.com/iotaledger/wasp/clients/iscmove"
 	"github.com/iotaledger/wasp/clients/iscmove/iscmoveclient"
 	"github.com/iotaledger/wasp/packages/chain"
@@ -120,7 +121,7 @@ func (ncc *ncChain) syncChainState(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	anchor := isc.NewStateAnchor(moveAnchor, cryptolib.NewAddressFromIota(moveAnchor.Owner), ncc.feed.GetISCPackageID())
+	anchor := isc.NewStateAnchor(moveAnchor, ncc.feed.GetISCPackageID())
 	ncc.anchorHandler(&anchor)
 
 	for _, req := range reqs {
@@ -148,7 +149,7 @@ func (ncc *ncChain) subscribeToUpdates(ctx context.Context, anchorID iotago.Obje
 			case <-ctx.Done():
 				return
 			case moveAnchor := <-anchorUpdates:
-				anchor := isc.NewStateAnchor(moveAnchor, cryptolib.NewAddressFromIota(moveAnchor.Owner), ncc.feed.GetISCPackageID())
+				anchor := isc.NewStateAnchor(moveAnchor, ncc.feed.GetISCPackageID())
 				ncc.anchorHandler(&anchor)
 			case req := <-newRequests:
 				onledgerReq, err := isc.OnLedgerFromRequest(req, cryptolib.NewAddressFromIota(&anchorID))

--- a/packages/origin/origin_test.go
+++ b/packages/origin/origin_test.go
@@ -89,7 +89,7 @@ func TestCreateOrigin(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	oriAnchor := isc.NewStateAnchor(anchorRef, stateSigner.Address(), l1starter.ISCPackageID())
+	oriAnchor := isc.NewStateAnchor(anchorRef, l1starter.ISCPackageID())
 	require.NotNil(t, oriAnchor)
 	anchor, err := client.GetAnchorFromObjectID(context.TODO(), oriAnchor.GetObjectID())
 	require.NoError(t, err)

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -242,8 +242,8 @@ func (env *Solo) GetChainByName(name string) *Chain {
 }
 
 const (
-	DefaultCommonAccountBaseTokens   = 5 * isc.Million
-	DefaultChainOriginatorBaseTokens = 5 * isc.Million
+	DefaultCommonAccountBaseTokens   = 50 * isc.Million
+	DefaultChainOriginatorBaseTokens = 50 * isc.Million
 )
 
 // NewChain deploys new default chain instance.

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -18,6 +18,7 @@ import (
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/logger"
+
 	"github.com/iotaledger/wasp/clients/iota-go/contracts"
 	"github.com/iotaledger/wasp/clients/iota-go/iotaclient"
 	"github.com/iotaledger/wasp/clients/iota-go/iotaclient/iotaclienttest"
@@ -408,11 +409,9 @@ func (ch *Chain) GetAnchor(stateIndex uint32) *isc.StateAnchor {
 		uint64(stateIndex),
 	)
 	require.NoError(ch.Env.T, err)
-	return &isc.StateAnchor{
-		Anchor:     anchor,
-		Owner:      ch.OriginatorAddress,
-		ISCPackage: ch.Env.ISCPackageID(),
-	}
+
+	stateAnchor := isc.NewStateAnchor(anchor, ch.Env.ISCPackageID())
+	return &stateAnchor
 }
 
 func (ch *Chain) GetLatestAnchor() *isc.StateAnchor {
@@ -421,16 +420,14 @@ func (ch *Chain) GetLatestAnchor() *isc.StateAnchor {
 		ch.ChainID.AsAddress().AsIotaAddress(),
 	)
 	require.NoError(ch.Env.T, err)
-	return &isc.StateAnchor{
-		Anchor:     anchor,
-		Owner:      ch.OriginatorAddress,
-		ISCPackage: ch.Env.ISCPackageID(),
-	}
+
+	stateAnchor := isc.NewStateAnchor(anchor, ch.Env.ISCPackageID())
+	return &stateAnchor
 }
 
 func (ch *Chain) GetLatestAnchorWithBalances() (*isc.StateAnchor, *isc.Assets) {
 	anchor := ch.GetLatestAnchor()
-	bals, err := ch.Env.ISCMoveClient().GetAssetsBagWithBalances(ch.Env.ctx, &anchor.Anchor.Object.Assets.ID)
+	bals, err := ch.Env.ISCMoveClient().GetAssetsBagWithBalances(ch.Env.ctx, &anchor.Anchor().Object.Assets.ID)
 	require.NoError(ch.Env.T, err)
 	return anchor, lo.Must(isc.AssetsFromAssetsBagWithBalances(bals))
 }

--- a/packages/testutil/l1starter/l1starter.go
+++ b/packages/testutil/l1starter/l1starter.go
@@ -59,6 +59,14 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
+func TestInSingleTestFunc(t *testing.T) {
+	flag.Parse()
+	iotaNode := Start(context.Background(), DefaultConfig)
+	t.Cleanup(func() {
+		iotaNode.Stop()
+	})
+}
+
 func ISCPackageID() iotago.PackageID {
 	return Instance().ISCPackageID
 }

--- a/packages/testutil/testchain/test_chain_ledger.go
+++ b/packages/testutil/testchain/test_chain_ledger.go
@@ -102,7 +102,7 @@ func (tcl *TestChainLedger) MakeTxChainOrigin(committeeAddress *cryptolib.Addres
 		},
 	)
 	require.NoError(tcl.t, err)
-	stateAnchor := isc.NewStateAnchor(anchorRef, tcl.governor.Address(), *tcl.iscPackage)
+	stateAnchor := isc.NewStateAnchor(anchorRef, *tcl.iscPackage)
 	require.NotNil(tcl.t, stateAnchor)
 	tcl.chainID = stateAnchor.ChainID()
 
@@ -237,6 +237,6 @@ func (tcl *TestChainLedger) FakeRotationTX(anchor *isc.StateAnchor, nextCommitte
 	anchorRef, err := tcl.l1client.L2().GetAnchorFromObjectID(context.Background(), anchor.GetObjectID())
 	require.NoError(tcl.t, err)
 
-	tmp := isc.NewStateAnchor(anchorRef, tcl.governor.Address(), *tcl.iscPackage)
+	tmp := isc.NewStateAnchor(anchorRef, *tcl.iscPackage)
 	return &tmp
 }

--- a/packages/testutil/testchain/test_chain_ledger.go
+++ b/packages/testutil/testchain/test_chain_ledger.go
@@ -190,8 +190,8 @@ func (tcl *TestChainLedger) UpdateAnchor(anchor *isc.StateAnchor) (*isc.StateAnc
 	if err != nil {
 		return nil, err
 	}
-	anchor.Anchor = anchorWithRef
-	return anchor, nil
+	stateAnchor := isc.NewStateAnchor(anchorWithRef, anchor.ISCPackage())
+	return &stateAnchor, nil
 }
 
 func (tcl *TestChainLedger) FakeRotationTX(anchor *isc.StateAnchor, nextCommitteeAddr *cryptolib.Address) *isc.StateAnchor {

--- a/packages/vm/core/governance/governanceimpl/statecontroller.go
+++ b/packages/vm/core/governance/governanceimpl/statecontroller.go
@@ -26,7 +26,7 @@ func rotateStateController(ctx isc.Sandbox, newStateControllerAddr *cryptolib.Ad
 		panic(vm.ErrUnauthorized)
 	}
 
-	if !newStateControllerAddr.Equals(ctx.StateAnchor().Owner) {
+	if !newStateControllerAddr.Equals(ctx.StateAnchor().Owner()) {
 		// rotate request to another address has been issued. State update will be taken over by VM and will have no effect
 		// By setting VarRotateToAddress we signal the VM this special situation
 		// VarRotateToAddress value should never persist in the state
@@ -38,10 +38,10 @@ func rotateStateController(ctx isc.Sandbox, newStateControllerAddr *cryptolib.Ad
 	// Two situations possible:
 	// - either there's no need to rotate
 	// - or it just has been rotated. In case of the second situation we emit a 'rotate' event
-	if !ctx.StateAnchor().Owner.Equals(newStateControllerAddr) {
+	if !ctx.StateAnchor().Owner().Equals(newStateControllerAddr) {
 		// state controller address recorded in the blocklog is different from the new one
 		// It means rotation happened
-		eventRotate(ctx, newStateControllerAddr, ctx.StateAnchor().Owner)
+		eventRotate(ctx, newStateControllerAddr, ctx.StateAnchor().Owner())
 		return
 	}
 	// no need to rotate because address does not change

--- a/packages/vm/vmimpl/runtask.go
+++ b/packages/vm/vmimpl/runtask.go
@@ -6,6 +6,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/iotaledger/hive.go/logger"
+
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/transaction"
 
@@ -50,7 +51,7 @@ func runTask(task *vm.VMTask) *vm.VMTaskResult {
 
 	prevL1Commitment := lo.Must(transaction.L1CommitmentFromAnchor(task.Anchor))
 	stateDraft := lo.Must(task.Store.NewStateDraft(task.Timestamp, prevL1Commitment))
-	txbuilder := vmtxbuilder.NewAnchorTransactionBuilder(task.Anchor.ISCPackage, task.Anchor, task.Anchor.Owner)
+	txbuilder := vmtxbuilder.NewAnchorTransactionBuilder(task.Anchor.ISCPackage(), task.Anchor, task.Anchor.Owner())
 	vmctx := newVmContext(task, stateDraft, txbuilder)
 	vmctx.init()
 

--- a/packages/vm/vmimpl/send.go
+++ b/packages/vm/vmimpl/send.go
@@ -19,8 +19,10 @@ func (reqctx *requestContext) send(params isc.RequestParameters) {
 		reqctx.vm.txbuilder.SendAssets(params.TargetAddress.AsIotaAddress(), params.Assets)
 	} else {
 		// sending cross chain request to a contract on the other chain
+
+		packageID := reqctx.vm.task.Anchor.ISCPackage()
 		reqctx.vm.txbuilder.SendCrossChainRequest(
-			&reqctx.vm.task.Anchor.ISCPackage,
+			&packageID,
 			params.TargetAddress.AsIotaAddress(),
 			params.Assets,
 			params.Metadata,

--- a/packages/vm/vmtxbuilder/txbuilder_test.go
+++ b/packages/vm/vmtxbuilder/txbuilder_test.go
@@ -47,7 +47,7 @@ func TestTxBuilderBasic(t *testing.T) {
 
 	selectedGasCoin := getCoinsRes.Data[0].Ref()
 
-	stateAnchor := isc.NewStateAnchor(anchor, chainSigner.Address(), iscPackage)
+	stateAnchor := isc.NewStateAnchor(anchor, iscPackage)
 	txb := vmtxbuilder.NewAnchorTransactionBuilder(iscPackage, &stateAnchor, chainSigner.Address())
 
 	req1 := createIscmoveReq(t, client, senderSigner, iscPackage, anchor)
@@ -114,7 +114,7 @@ func TestTxBuilderSendAssetsAndRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	selectedGasCoin := getCoinsRes.Data[2].Ref()
-	stateAnchor := isc.NewStateAnchor(anchor, chainSigner.Address(), iscPackage)
+	stateAnchor := isc.NewStateAnchor(anchor, iscPackage)
 	txb1 := vmtxbuilder.NewAnchorTransactionBuilder(iscPackage, &stateAnchor, chainSigner.Address())
 
 	req1 := createIscmoveReq(t, client, senderSigner, iscPackage, anchor)
@@ -222,7 +222,7 @@ func TestTxBuilderSendCrossChainRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	stateAnchor1 := isc.NewStateAnchor(anchor1, signer.Address(), iscPackage1)
+	stateAnchor1 := isc.NewStateAnchor(anchor1, iscPackage1)
 	txb1 := vmtxbuilder.NewAnchorTransactionBuilder(iscPackage1, &stateAnchor1, signer.Address())
 
 	req1 := createIscmoveReq(t, client, signer, iscPackage1, anchor1)
@@ -300,7 +300,7 @@ func TestTxBuilderSendCrossChainRequest(t *testing.T) {
 	crossChainRequestRef, err := txnResponse2.GetCreatedObjectInfo(iscmove.RequestModuleName, iscmove.RequestObjectName)
 	require.NoError(t, err)
 
-	stateAnchor2 := isc.NewStateAnchor(anchor2, signer.Address(), iscPackage1)
+	stateAnchor2 := isc.NewStateAnchor(anchor2, iscPackage1)
 	txb3 := vmtxbuilder.NewAnchorTransactionBuilder(iscPackage1, &stateAnchor2, signer.Address())
 
 	reqWithObj, err := client.L2().GetRequestFromObjectID(context.Background(), crossChainRequestRef.ObjectID)

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/iotaledger/hive.go/logger"
 	iotago "github.com/iotaledger/iota.go/v3"
+
 	"github.com/iotaledger/wasp/clients"
 	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/clients/apiextensions"
@@ -297,7 +298,6 @@ func (clu *Cluster) DeployChain(allPeers, committeeNodes []int, quorum uint16, s
 			Prefix:            "[cluster] ",
 			StateMetadata:     stateMetaData,
 		},
-		stateAddr,
 		stateAddr,
 	)
 	if err != nil {


### PR DESCRIPTION
* Changes New/StateAnchor to use the Owner of the AnchorWithRef argument instead of requiring it in the second argument again.
* Fixes all files using the NewStateAnchor 
* Fixes some tests in cons/cmt_log that still uses Iota.go/v3 Stardust types
* Fixes chain deployment in the wasp-cli by using a correct Gas coin