### PR TITLE
fix: Prevent invalid cointype in allowance

### DIFF
--- a/clients/iota-go/iotajsonrpc/balance.go
+++ b/clients/iota-go/iotajsonrpc/balance.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/iotaledger/wasp/clients/iota-go/iotago"
+	"github.com/iotaledger/wasp/packages/util/bcs"
 )
 
 // this type "CoinType" is used only in iota-go and iscmoveclient
@@ -29,6 +30,13 @@ func MustCoinTypeFromString(s string) CoinType {
 
 func (t CoinType) String() string {
 	return string(t)
+}
+
+func (t *CoinType) UnmarshalBCS(d *bcs.Decoder) error {
+	var err error
+	s := bcs.Decode[string](d)
+	*t, err = CoinTypeFromString(s)
+	return err
 }
 
 func (t CoinType) TypeTag() iotago.TypeTag {

--- a/clients/iscmove/isc_test.go
+++ b/clients/iscmove/isc_test.go
@@ -6,11 +6,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotaledger/wasp/clients/iota-go/iotaclient"
 	"github.com/iotaledger/wasp/clients/iota-go/iotago"
 	"github.com/iotaledger/wasp/clients/iota-go/iotago/iotatest"
+	"github.com/iotaledger/wasp/clients/iota-go/iotajsonrpc"
 	testcommon "github.com/iotaledger/wasp/clients/iota-go/test_common"
 	"github.com/iotaledger/wasp/clients/iscmove"
+	"github.com/iotaledger/wasp/clients/iscmove/iscmoveclient"
 	"github.com/iotaledger/wasp/clients/iscmove/iscmovetest"
+	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/util/bcs"
 )
 
@@ -42,4 +46,29 @@ func TestIscCodec(t *testing.T) {
 	}
 
 	bcs.TestCodec(t, anchorRef)
+}
+
+func TestUnmarshalBCS(t *testing.T) {
+	var targetReq iscmoveclient.MoveRequest
+	req := iscmoveclient.MoveRequest{
+		ID:     *iotatest.RandomAddress(),
+		Sender: cryptolib.NewAddressFromIota(iotatest.RandomAddress()),
+		AssetsBag: iscmoveclient.Referent[iscmove.AssetsBagWithBalances]{
+			ID: *iotatest.RandomAddress(),
+			Value: &iscmove.AssetsBagWithBalances{
+				AssetsBag: iscmovetest.RandomAssetsBag(),
+				Balances:  iscmove.AssetsBagBalances{},
+			},
+		},
+		Message: *iscmovetest.RandomMessage(),
+		Allowance: []iscmove.CoinAllowance{
+			{CoinType: iotajsonrpc.IotaCoinType, Balance: 100},
+			{CoinType: "0x1:AB:ab", Balance: 200},
+		},
+		GasBudget: 100,
+	}
+	b, err := bcs.Marshal(&req)
+	require.NoError(t, err)
+	err = iotaclient.UnmarshalBCS(b, &targetReq)
+	require.NotNil(t, err)
 }

--- a/clients/iscmove/iscmoveclient/client_request.go
+++ b/clients/iscmove/iscmoveclient/client_request.go
@@ -194,7 +194,7 @@ func (c *Client) GetRequestFromObjectID(
 }
 
 func (c *Client) parseRequestAndFetchAssetsBag(obj *iotajsonrpc.IotaObjectData) (*iscmove.RefWithObject[iscmove.Request], error) {
-	var req moveRequest
+	var req MoveRequest
 	err := iotaclient.UnmarshalBCS(obj.Bcs.Data.MoveObject.BcsBytes, &req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal BCS: %w", err)

--- a/clients/iscmove/iscmoveclient/iscmovetypes.go
+++ b/clients/iscmove/iscmoveclient/iscmovetypes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/iotaledger/wasp/packages/cryptolib"
 )
 
-type referent[T any] struct {
+type Referent[T any] struct {
 	ID    iotago.ObjectID
 	Value *T `bcs:"optional"`
 }
@@ -14,7 +14,7 @@ type referent[T any] struct {
 // moveAnchor is the BCS equivalent for the move type Anchor
 type moveAnchor struct {
 	ID            iotago.ObjectID
-	Assets        referent[iscmove.AssetsBag]
+	Assets        Referent[iscmove.AssetsBag]
 	StateMetadata []byte
 	StateIndex    uint32
 }
@@ -28,17 +28,17 @@ func (ma *moveAnchor) ToAnchor() *iscmove.Anchor {
 	}
 }
 
-type moveRequest struct {
+type MoveRequest struct {
 	ID     iotago.ObjectID
 	Sender *cryptolib.Address
 	// XXX balances are empty if we don't fetch the dynamic fields
-	AssetsBag referent[iscmove.AssetsBagWithBalances] // Need to decide if we want to use this Referent wrapper as well. Could probably be of *AssetsBag with `bcs:"optional`
+	AssetsBag Referent[iscmove.AssetsBagWithBalances] // Need to decide if we want to use this Referent wrapper as well. Could probably be of *AssetsBag with `bcs:"optional`
 	Message   iscmove.Message
 	Allowance []iscmove.CoinAllowance
 	GasBudget uint64
 }
 
-func (mr *moveRequest) ToRequest() *iscmove.Request {
+func (mr *MoveRequest) ToRequest() *iscmove.Request {
 	assets := iscmove.NewAssets(0)
 	for _, allowance := range mr.Allowance {
 		assets.AddCoin(allowance.CoinType, allowance.Balance)

--- a/packages/isc/assets.go
+++ b/packages/isc/assets.go
@@ -263,7 +263,11 @@ func AssetsFromAssetsBagWithBalances(assetsBag *iscmove.AssetsBagWithBalances) (
 func AssetsFromISCMove(assets *iscmove.Assets) (*Assets, error) {
 	ret := NewEmptyAssets()
 	for k, v := range assets.Coins {
-		ret.Coins.Add(coin.MustTypeFromString(k.String()), coin.Value(v))
+		coinType, err := coin.TypeFromString(k.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse string to coin.Type: %w", err)
+		}
+		ret.Coins.Add(coinType, coin.Value(v))
 	}
 	return ret, nil
 }


### PR DESCRIPTION
An attacker may place invalid cointype in allowance which will make
`OnLedgerFromRequest()` simply panic. Now the Umarshalled allowance in
onledger request must be a valid coin type

close #477