### PR TITLE
Activate docs upload workflow

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -1,8 +1,8 @@
 name: Build and upload API docs
 
 on:
-#  release:
-#    types: [published]
+  release:
+    types: [published]
 
 env:
   GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Description of change

Not sure why it was deactivated, but I think we can activate it again?

## How the change has been tested

Tested with `act`. Docs were successfully generated and uploaded
