### PR TITLE
chore: base58 to base64

### DIFF
--- a/clients/iota-go/iotaclient/iotaclienttest/api_read_test.go
+++ b/clients/iota-go/iotaclient/iotaclienttest/api_read_test.go
@@ -2,10 +2,10 @@ package iotaclienttest
 
 import (
 	"context"
+	"encoding/base64"
 	"strconv"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcutil/base58"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/wasp/clients"
@@ -152,8 +152,12 @@ func TestGetEvents(t *testing.T) {
 		require.Equal(t, targetStructTag.TypeParams[1].Struct.Module, event.Type.TypeParams[1].Struct.Module)
 		require.Equal(t, targetStructTag.TypeParams[1].Struct.Name, event.Type.TypeParams[1].Struct.Name)
 		require.Equal(t, targetStructTag.TypeParams[1].Struct.TypeParams, event.Type.TypeParams[1].Struct.TypeParams)
-		targetBcsBase85 := base58.Decode("yNS5iDS3Gvdo3DhXdtFpuTS12RrSiNkrvjcm2rejntCuqWjF1DdwnHgjowdczAkR18LQHcBqbX2tWL76rys9rTCzG6vm7Tg34yqUkpFSMqNkcS6cfWbN8SdVsxn5g4ZEQotdBgEFn8yN7hVZ7P1MKvMwWf")
-		require.Equal(t, targetBcsBase85, event.Bcs.Data())
+		targetBcsBase64, err := base64.StdEncoding.DecodeString(
+			"RAW1DXkf0zRnVOgXGqq2vC7SbCxG790DPBSzCuUHrDObF2oAAAAAgDaEAkYyhy8PAPR7xPX" +
+				"+lV7LBzuZSXWnlDlx1Jfi/kERQQnEXcSfTZAuAHT+QdwAAAAAdP5B3AAAALycEAAAAAAAqXmyiI8BAAA=",
+		)
+		require.NoError(t, err)
+		require.Equal(t, targetBcsBase64, event.Bcs.Data())
 	}
 }
 

--- a/clients/iota-go/iotajsonrpc/dynamic_field.go
+++ b/clients/iota-go/iotajsonrpc/dynamic_field.go
@@ -8,7 +8,7 @@ import (
 // in iotago/crates/iotago-types/src/dynamic_field.rs
 type DynamicFieldInfo struct {
 	Name       iotago.DynamicFieldName                        `json:"name"`
-	BcsName    iotago.Base58                                  `json:"bcsName"`
+	BcsName    iotago.Base64Data                              `json:"bcsName"`
 	Type       serialization.TagJson[iotago.DynamicFieldType] `json:"type"`
 	ObjectType string                                         `json:"objectType"`
 	ObjectID   iotago.ObjectID                                `json:"objectId"`

--- a/clients/iota-go/iotajsonrpc/events.go
+++ b/clients/iota-go/iotajsonrpc/events.go
@@ -23,9 +23,9 @@ type IotaEvent struct {
 	Type *iotago.StructTag `json:"type"`
 	// Parsed json value of the event
 	ParsedJson interface{} `json:"parsedJson,omitempty"`
-	// Base 58 encoded bcs bytes of the move event
-	Bcs         iotago.Base58 `json:"bcs"`
-	TimestampMs *BigInt       `json:"timestampMs,omitempty"`
+	// Base 64 encoded bcs bytes of the move event
+	Bcs         iotago.Base64Data `json:"bcs"`
+	TimestampMs *BigInt           `json:"timestampMs,omitempty"`
 }
 
 type EventPage = Page[IotaEvent, EventId]

--- a/clients/iota-go/iotajsonrpc/events_test.go
+++ b/clients/iota-go/iotajsonrpc/events_test.go
@@ -31,7 +31,7 @@ func TestIotaEventDecode(t *testing.T) {
         "pool_id": "0x4405b50d791fd3346754e8171aaab6bc2ed26c2c46efdd033c14b30ae507ac33",
         "price": "863800"
       },
-      "bcs": "yNS5iDS3Gvdo3DhXdtFpuTS12RrSiNkrvjcm2rejntCt1jjM24MvS8o5s9dDHCe4pxwJvVbm1pBWymUgAGmG7SAZpxJSocaXSFj5oW1YT2KkZoEieUfPRbmcmf6fAHYHi5Nb1Hq73RFXjXG5soSUsgZyrP",
+      "bcs": "RAW1DXkf0zRnVOgXGqq2vC7SbCxG790DPBSzCuUHrDN1LIQAAAAAgF51cLjUi+I9AKVPiG3ii58jsQ5vpoI5OmmIBZhBKcuO06jdQses9ChbAHgFG5gBAAAAeAUbmAEAADguDQAAAAAAL1WXv5ABAAA=",
       "timestampMs": "1721197686017"
     }`)
 	var event iotajsonrpc.IotaEvent


### PR DESCRIPTION
Based on new requirements, changing base58 to base64 for BCS fields.
An additional fix for chain deployments.