### PR TITLE
fix: wasp-cli deployment, add inspection tools

### DIFF
--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -158,7 +157,7 @@ func initDepositCmd() *cobra.Command {
 					)
 				})
 
-				fmt.Print(res.Digest.String())
+				log.Printf("Posted TX: %s\n", res.Digest)
 			} else {
 				// deposit to some other agentID
 				agentID := util.AgentIDFromString(args[0])
@@ -176,7 +175,7 @@ func initDepositCmd() *cobra.Command {
 				)
 
 				log.Check(err)
-				fmt.Printf("Posted TX: %s\n", res.Digest)
+				log.Printf("Posted TX: %s\n", res.Digest)
 			}
 		},
 	}

--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -18,8 +18,8 @@ import (
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
-	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
+	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
@@ -147,7 +147,7 @@ func initDepositCmd() *cobra.Command {
 				tokens := util.ParseFungibleTokens(util.ArgsToFungibleTokensStr(args))
 				allowance := isc.NewAssets(tokens.BaseTokens() / 10)
 
-				util.WithSCTransaction(ctx, client, func() (*iotajsonrpc.IotaTransactionBlockResponse, error) {
+				res := util.WithSCTransaction(ctx, client, func() (*iotajsonrpc.IotaTransactionBlockResponse, error) {
 					return cliclients.ChainClient(client, chainID).PostRequest(ctx,
 						accounts.FuncDeposit.Message(),
 						chainclient.PostRequestParams{
@@ -157,6 +157,8 @@ func initDepositCmd() *cobra.Command {
 						},
 					)
 				})
+
+				fmt.Print(res.Digest.String())
 			} else {
 				// deposit to some other agentID
 				agentID := util.AgentIDFromString(args[0])

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -175,7 +175,7 @@ func initDeployCmd() *cobra.Command {
 			gasCoin, err := CreateAndSendGasCoin(ctx, l1Client, kp, committeeAddr.AsIotaAddress(), l1Params)
 			log.Check(err)
 
-			stateMetadata := initializeNewChainState(committeeAddr, gasCoin, l1Params)
+			stateMetadata := initializeNewChainState(kp.Address(), gasCoin, l1Params)
 
 			par := apilib.CreateChainParams{
 				Layer1Client:      l1Client,

--- a/tools/wasp-cli/inspection/anchor.go
+++ b/tools/wasp-cli/inspection/anchor.go
@@ -1,0 +1,64 @@
+package inspection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/spf13/cobra"
+
+	"github.com/iotaledger/wasp/clients/iota-go/iotago"
+	"github.com/iotaledger/wasp/packages/origin"
+	"github.com/iotaledger/wasp/packages/transaction"
+	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+)
+
+func initAnchorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "anchor <AnchorID>",
+		Short: "Show the content of an Anchor",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			objectID, err := iotago.ObjectIDFromHex(args[0])
+			log.Check(err)
+
+			ctx := context.Background()
+			anchor, err := cliclients.L2Client().GetAnchorFromObjectID(ctx, objectID)
+			log.Check(err)
+
+			fmt.Printf("Anchor:\n")
+			fmt.Printf("\tID: %s\n", anchor.ObjectID)
+			fmt.Printf("\tAssetsBag: %s\n", anchor.Object.Assets.Value.ID)
+			fmt.Printf("\tStateIndex: %d\n", anchor.Object.StateIndex)
+			fmt.Printf("\tStateMetadata: %s\n", hexutil.Encode(anchor.Object.StateMetadata))
+
+			fmt.Print("\nStateMetadata decoded:\n")
+			metadata, err := transaction.StateMetadataFromBytes(anchor.Object.StateMetadata)
+			if err != nil {
+				fmt.Printf("\tCould not decode state metadata: %v\n", err)
+				return
+			}
+
+			fmt.Printf("\tGasCoinObjectID: %s\n", metadata.GasCoinObjectID)
+			fmt.Printf("\tInitDeposit: %d\n", metadata.InitDeposit)
+			fmt.Printf("\tL1Commitment: BlockHash:%s, TrieRoot:%s\n",
+				metadata.L1Commitment.BlockHash().String(),
+				metadata.L1Commitment.TrieRoot().String())
+			fmt.Printf("\tPublicUrl: %s\n", metadata.PublicURL)
+			fmt.Printf("\tSchemaVersion: %d\n", metadata.SchemaVersion)
+
+			initParams, err := origin.DecodeInitParams(metadata.InitParams)
+			if err != nil {
+				fmt.Printf("\tCould not decode Init Params! Params: %s\n", metadata.InitParams.String())
+				return
+			}
+
+			fmt.Print("\n\tInitParams:\n")
+			fmt.Printf("\t\tChainOwner: %s\n", initParams.ChainOwner)
+			fmt.Printf("\t\tBlockKeepAmount: %d\n", initParams.BlockKeepAmount)
+			fmt.Printf("\t\tDeployTestContracts: %v\n", initParams.DeployTestContracts)
+			fmt.Printf("\t\tEVM ChainID: %d\n", initParams.EVMChainID)
+		},
+	}
+}

--- a/tools/wasp-cli/inspection/anchor.go
+++ b/tools/wasp-cli/inspection/anchor.go
@@ -35,8 +35,7 @@ func initAnchorCmd() *cobra.Command {
 			log.Printf("\nStateMetadata decoded:\n")
 			metadata, err := transaction.StateMetadataFromBytes(anchor.Object.StateMetadata)
 			if err != nil {
-				log.Printf("\tCould not decode state metadata: %v\n", err)
-				return
+				log.Fatalf("\tCould not decode state metadata: %v\n", err)
 			}
 
 			log.Printf("\tGasCoinObjectID: %s\n", metadata.GasCoinObjectID)

--- a/tools/wasp-cli/inspection/anchor.go
+++ b/tools/wasp-cli/inspection/anchor.go
@@ -47,8 +47,7 @@ func initAnchorCmd() *cobra.Command {
 			log.Printf("\tSchemaVersion: %d\n", metadata.SchemaVersion)
 
 			if anchor.Object.StateIndex != 0 {
-				log.Printf("Skipping InitParams, as state index is not 0\n")
-				return
+				log.Fatalf("Skipping InitParams, as state index is not 0\n")
 			}
 
 			initParams, err := origin.DecodeInitParams(metadata.InitParams)

--- a/tools/wasp-cli/inspection/anchor.go
+++ b/tools/wasp-cli/inspection/anchor.go
@@ -2,7 +2,6 @@ package inspection
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/spf13/cobra"
@@ -27,43 +26,42 @@ func initAnchorCmd() *cobra.Command {
 			anchor, err := cliclients.L2Client().GetAnchorFromObjectID(ctx, objectID)
 			log.Check(err)
 
-			fmt.Printf("Anchor:\n")
-			fmt.Printf("\tID: %s\n", anchor.ObjectID)
-			fmt.Printf("\tAssetsBag: %s\n", anchor.Object.Assets.Value.ID)
-			fmt.Printf("\tStateIndex: %d\n", anchor.Object.StateIndex)
-			fmt.Printf("\tStateMetadata: %s\n", hexutil.Encode(anchor.Object.StateMetadata))
+			log.Printf("Anchor:\n")
+			log.Printf("\tID: %s\n", anchor.ObjectID)
+			log.Printf("\tAssetsBag: %s\n", anchor.Object.Assets.Value.ID)
+			log.Printf("\tStateIndex: %d\n", anchor.Object.StateIndex)
+			log.Printf("\tStateMetadata: %s\n", hexutil.Encode(anchor.Object.StateMetadata))
 
-			fmt.Print("\nStateMetadata decoded:\n")
+			log.Printf("\nStateMetadata decoded:\n")
 			metadata, err := transaction.StateMetadataFromBytes(anchor.Object.StateMetadata)
 			if err != nil {
-				fmt.Printf("\tCould not decode state metadata: %v\n", err)
+				log.Printf("\tCould not decode state metadata: %v\n", err)
 				return
 			}
 
-			fmt.Printf("\tGasCoinObjectID: %s\n", metadata.GasCoinObjectID)
-			fmt.Printf("\tInitDeposit: %d\n", metadata.InitDeposit)
-			fmt.Printf("\tL1Commitment: BlockHash:%s, TrieRoot:%s\n",
+			log.Printf("\tGasCoinObjectID: %s\n", metadata.GasCoinObjectID)
+			log.Printf("\tInitDeposit: %d\n", metadata.InitDeposit)
+			log.Printf("\tL1Commitment: BlockHash:%s, TrieRoot:%s\n",
 				metadata.L1Commitment.BlockHash().String(),
 				metadata.L1Commitment.TrieRoot().String())
-			fmt.Printf("\tPublicUrl: %s\n", metadata.PublicURL)
-			fmt.Printf("\tSchemaVersion: %d\n", metadata.SchemaVersion)
+			log.Printf("\tPublicUrl: %s\n", metadata.PublicURL)
+			log.Printf("\tSchemaVersion: %d\n", metadata.SchemaVersion)
 
 			if anchor.Object.StateIndex != 0 {
-				fmt.Print("Skipping InitParams, as state index is not 0\n")
+				log.Printf("Skipping InitParams, as state index is not 0\n")
 				return
 			}
 
 			initParams, err := origin.DecodeInitParams(metadata.InitParams)
 			if err != nil {
-				fmt.Printf("\tCould not decode Init Params! Params: %s\n", metadata.InitParams.String())
-				return
+				log.Fatalf("\tCould not decode Init Params! Params: %s\n", metadata.InitParams.String())
 			}
 
-			fmt.Print("\n\tInitParams:\n")
-			fmt.Printf("\t\tChainOwner: %s\n", initParams.ChainOwner)
-			fmt.Printf("\t\tBlockKeepAmount: %d\n", initParams.BlockKeepAmount)
-			fmt.Printf("\t\tDeployTestContracts: %v\n", initParams.DeployTestContracts)
-			fmt.Printf("\t\tEVM ChainID: %d\n", initParams.EVMChainID)
+			log.Printf("\n\tInitParams:\n")
+			log.Printf("\t\tChainOwner: %s\n", initParams.ChainOwner)
+			log.Printf("\t\tBlockKeepAmount: %d\n", initParams.BlockKeepAmount)
+			log.Printf("\t\tDeployTestContracts: %v\n", initParams.DeployTestContracts)
+			log.Printf("\t\tEVM ChainID: %d\n", initParams.EVMChainID)
 		},
 	}
 }

--- a/tools/wasp-cli/inspection/anchor.go
+++ b/tools/wasp-cli/inspection/anchor.go
@@ -48,6 +48,11 @@ func initAnchorCmd() *cobra.Command {
 			fmt.Printf("\tPublicUrl: %s\n", metadata.PublicURL)
 			fmt.Printf("\tSchemaVersion: %d\n", metadata.SchemaVersion)
 
+			if anchor.Object.StateIndex != 0 {
+				fmt.Print("Skipping InitParams, as state index is not 0\n")
+				return
+			}
+
 			initParams, err := origin.DecodeInitParams(metadata.InitParams)
 			if err != nil {
 				fmt.Printf("\tCould not decode Init Params! Params: %s\n", metadata.InitParams.String())

--- a/tools/wasp-cli/inspection/assetsbag.go
+++ b/tools/wasp-cli/inspection/assetsbag.go
@@ -27,11 +27,11 @@ func initAssetsBagCmd() *cobra.Command {
 			log.Printf("Balances:\n")
 
 			for n, c := range assetsBag.Coins {
-				log.Printf("	%s: %v\n", n, c)
+				log.Printf("\t%s: %v\n", n, c)
 			}
 
 			for n, c := range assetsBag.Objects {
-				log.Printf("	%s: %v\n", n, c)
+				log.Printf("\t%s: %v\n", n, c)
 			}
 		},
 	}

--- a/tools/wasp-cli/inspection/assetsbag.go
+++ b/tools/wasp-cli/inspection/assetsbag.go
@@ -2,7 +2,6 @@ package inspection
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -24,15 +23,15 @@ func initAssetsBagCmd() *cobra.Command {
 			assetsBag, err := cliclients.L2Client().GetAssetsBagWithBalances(ctx, bagId)
 			log.Check(err)
 
-			fmt.Printf("AssetsBag:\n	ID: %s\n	Size: %d\n\n", assetsBag.ID, assetsBag.Size)
-			fmt.Println("Balances:")
+			log.Printf("AssetsBag:\n	ID: %s\n	Size: %d\n\n", assetsBag.ID, assetsBag.Size)
+			log.Printf("Balances:\n")
 
 			for n, c := range assetsBag.Coins {
-				fmt.Printf("	%s: %v\n", n, c)
+				log.Printf("	%s: %v\n", n, c)
 			}
 
 			for n, c := range assetsBag.Objects {
-				fmt.Printf("	%s: %v\n", n, c)
+				log.Printf("	%s: %v\n", n, c)
 			}
 		},
 	}

--- a/tools/wasp-cli/inspection/assetsbag.go
+++ b/tools/wasp-cli/inspection/assetsbag.go
@@ -1,0 +1,39 @@
+package inspection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/iotaledger/wasp/clients/iota-go/iotago"
+	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+)
+
+func initAssetsBagCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "assetsbag <AssetsBagID>",
+		Short: "Show the content of an AssetsBag",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			bagId, err := iotago.ObjectIDFromHex(args[0])
+			log.Check(err)
+
+			ctx := context.Background()
+			assetsBag, err := cliclients.L2Client().GetAssetsBagWithBalances(ctx, bagId)
+			log.Check(err)
+
+			fmt.Printf("AssetsBag:\n	ID: %s\n	Size: %d\n\n", assetsBag.ID, assetsBag.Size)
+			fmt.Println("Balances:")
+
+			for n, c := range assetsBag.Coins {
+				fmt.Printf("	%s: %v\n", n, c)
+			}
+
+			for n, c := range assetsBag.Objects {
+				fmt.Printf("	%s: %v\n", n, c)
+			}
+		},
+	}
+}

--- a/tools/wasp-cli/inspection/cmd.go
+++ b/tools/wasp-cli/inspection/cmd.go
@@ -1,0 +1,26 @@
+package inspection
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+)
+
+func initInspect() *cobra.Command {
+	return &cobra.Command{
+		Use:   "inspect <command>",
+		Short: "Get information about a given object",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Check(cmd.Help())
+		},
+	}
+}
+
+func Init(rootCmd *cobra.Command) {
+	inspectCmd := initInspect()
+	rootCmd.AddCommand(inspectCmd)
+
+	inspectCmd.AddCommand(initAssetsBagCmd())
+	inspectCmd.AddCommand(initAnchorCmd())
+}

--- a/tools/wasp-cli/main.go
+++ b/tools/wasp-cli/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/completion"
 	"github.com/iotaledger/wasp/tools/wasp-cli/decode"
 	"github.com/iotaledger/wasp/tools/wasp-cli/disrec"
+	"github.com/iotaledger/wasp/tools/wasp-cli/inspection"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/iotaledger/wasp/tools/wasp-cli/metrics"
 	"github.com/iotaledger/wasp/tools/wasp-cli/peering"
@@ -85,6 +86,7 @@ func init() {
 	peering.Init(rootCmd)
 	metrics.Init(rootCmd)
 	disrec.Init(rootCmd)
+	inspection.Init(rootCmd)
 }
 
 func main() {


### PR DESCRIPTION
Fixes the ChainOwner setting, adds `inspect assetsbag`, `inspect anchor` 