### PR TITLE
fix: register-erc20-native-token, add: set-coin-metadata

### DIFF
--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -144,7 +144,8 @@ func initDepositCmd() *cobra.Command {
 			if strings.Contains(args[0], "|") {
 				// deposit to own agentID
 				tokens := util.ParseFungibleTokens(util.ArgsToFungibleTokensStr(args))
-				allowance := isc.NewAssets(tokens.BaseTokens() / 10)
+				allowance := tokens.Clone()
+				allowance.SetBaseTokens(allowance.BaseTokens() / 10)
 
 				res := util.WithSCTransaction(ctx, client, func() (*iotajsonrpc.IotaTransactionBlockResponse, error) {
 					return cliclients.ChainClient(client, chainID).PostRequest(ctx,
@@ -162,7 +163,8 @@ func initDepositCmd() *cobra.Command {
 				// deposit to some other agentID
 				agentID := util.AgentIDFromString(args[0])
 				tokens := util.ParseFungibleTokens(util.ArgsToFungibleTokensStr(args[1:]))
-				allowance := isc.NewAssets(tokens.BaseTokens() - 10000)
+				allowance := tokens.Clone()
+				allowance.SetBaseTokens(allowance.BaseTokens() / 10)
 
 				res, err := cliclients.ChainClient(client, chainID).PostRequest(
 					ctx,

--- a/tools/wasp-cli/chain/cmd.go
+++ b/tools/wasp-cli/chain/cmd.go
@@ -42,6 +42,7 @@ func Init(rootCmd *cobra.Command) {
 	chainCmd.AddCommand(initPermissionlessAccessNodesCmd())
 	chainCmd.AddCommand(initAddChainCmd())
 	chainCmd.AddCommand(initRegisterERC20NativeTokenCmd())
+	chainCmd.AddCommand(initSetCoinMetadataCmd())
 	// chainCmd.AddCommand(initCreateNativeTokenCmd())
 	chainCmd.AddCommand(initMetadataCmd())
 }

--- a/tools/wasp-cli/chain/set-coin-metadata.go
+++ b/tools/wasp-cli/chain/set-coin-metadata.go
@@ -8,13 +8,14 @@ import (
 	"github.com/iotaledger/wasp/clients/chainclient"
 	"github.com/iotaledger/wasp/clients/iota-go/iotaclient"
 	"github.com/iotaledger/wasp/packages/coin"
-	"github.com/iotaledger/wasp/packages/vm/core/evm"
+	"github.com/iotaledger/wasp/packages/parameters"
+	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
-func initRegisterERC20NativeTokenCmd() *cobra.Command {
+func initSetCoinMetadataCmd() *cobra.Command {
 	var (
 		node           string
 		chainAliasName string
@@ -22,8 +23,8 @@ func initRegisterERC20NativeTokenCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "register-erc20-native-token <coinType>",
-		Short: "Call evm core contract registerERC20NativeToken entry point",
+		Use:   "set-coin-metadata <coinType>",
+		Short: "Registers coin metadata",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
@@ -36,7 +37,21 @@ func initRegisterERC20NativeTokenCmd() *cobra.Command {
 				log.Fatalf("invalid coin type: %s => %v", coinType, err)
 			}
 
-			request := evm.FuncRegisterERC20Coin.Message(coinType)
+			coinInfo, err := cliclients.L1Client().GetCoinMetadata(ctx, args[0])
+			log.Check(err)
+
+			totalSupply, err := cliclients.L1Client().GetTotalSupply(ctx, args[0])
+			log.Check(err)
+
+			request := accounts.SetCoinMetadata.Message(&parameters.IotaCoinInfo{
+				CoinType:    coinType,
+				Name:        coinInfo.Name,
+				Symbol:      coinInfo.Symbol,
+				Description: coinInfo.Description,
+				IconURL:     coinInfo.IconUrl,
+				Decimals:    coinInfo.Decimals,
+				TotalSupply: coin.Value(totalSupply.Value.Uint64()),
+			})
 
 			postRequest(ctx, client, chainAliasName, request, chainclient.PostRequestParams{
 				GasBudget: iotaclient.DefaultGasBudget,


### PR DESCRIPTION
This fixes 

* `register-erc20-native-token`
* depositing of native tokens / objects
 
 and adds `set-coin-metadata`.

It allows the registration of deposited L1 native tokens inside the EVM. Which will then show up in Metamask and the explorer.