### PR TITLE
audit: #63 fix NewSigner uses incorrect prefix for unsupported Secp256k1 key scheme

### DIFF
--- a/clients/iota-go/iotaclient/iotaclienttest/api_exented_test.go
+++ b/clients/iota-go/iotaclient/iotaclienttest/api_exented_test.go
@@ -67,7 +67,7 @@ func TestGetDynamicFieldObject(t *testing.T) {
 
 func TestGetOwnedObjects(t *testing.T) {
 	client := l1starter.Instance().L1Client()
-	signer := iotasigner.NewSignerByIndex(testcommon.TestSeed, iotasigner.KeySchemeFlagEd25519, 0)
+	signer := iotasigner.NewSignerByIndex(testcommon.TestSeed, iotasigner.KeySchemeFlagDefault, 0)
 	t.Run(
 		"struct tag", func(t *testing.T) {
 			structTag, err := iotago.StructTagFromString("0x2::coin::Coin<0x2::iota::IOTA>")

--- a/clients/iota-go/iotasigner/iotasignertest/random.go
+++ b/clients/iota-go/iotasigner/iotasignertest/random.go
@@ -14,7 +14,7 @@ func RandomSigner() iotasigner.Signer {
 	if err != nil {
 		panic(err)
 	}
-	return iotasigner.NewSigner(b, iotasigner.KeySchemeFlagIotaEd25519)
+	return iotasigner.NewSigner(b, iotasigner.KeySchemeFlagDefault)
 }
 
 func RandomSignedTransaction(signers ...iotasigner.Signer) iotasigner.SignedTransaction {

--- a/clients/iota-go/iotasigner/key_schemes.go
+++ b/clients/iota-go/iotasigner/key_schemes.go
@@ -7,7 +7,7 @@ import (
 
 type KeySchemeFlag byte
 
-var KeySchemeFlagDefault = KeySchemeFlagIotaEd25519
+var KeySchemeFlagDefault = KeySchemeFlagEd25519
 
 const (
 	KeySchemeFlagEd25519 KeySchemeFlag = iota
@@ -17,8 +17,7 @@ const (
 	KeySchemeFlagBLS12381
 	KeySchemeFlagZkLoginAuthenticator
 
-	KeySchemeFlagIotaEd25519 KeySchemeFlag = math.MaxUint8 - 1 // special case for iotago ed25519
-	KeySchemeFlagError                     = math.MaxUint8
+	KeySchemeFlagError = math.MaxUint8
 )
 
 func (k KeySchemeFlag) Byte() byte {

--- a/clients/iota-go/iotasigner/signer.go
+++ b/clients/iota-go/iotasigner/signer.go
@@ -75,8 +75,6 @@ func NewSigner(seed []byte, flag KeySchemeFlag) *InMemorySigner {
 	switch flag {
 	case KeySchemeFlagEd25519:
 		buf = []byte{KeySchemeFlagEd25519.Byte()}
-	case KeySchemeFlagSecp256k1:
-		buf = []byte{KeySchemeFlagEd25519.Byte()}
 	case KeySchemeFlagIotaEd25519:
 		buf = []byte{}
 	default:

--- a/clients/iota-go/iotasigner/signer_test.go
+++ b/clients/iota-go/iotasigner/signer_test.go
@@ -14,11 +14,7 @@ import (
 )
 
 func TestNewSigner(t *testing.T) {
-	testIotaAddress := iotago.MustAddressFromHex("0x786dff8a4ee13d45b502c8f22f398e3517e6ec78aa4ae564c348acb07fad7f50")
-	signer, err := iotasigner.NewSignerWithMnemonic(testcommon.TestMnemonic, iotasigner.KeySchemeFlagIotaEd25519)
-	require.NoError(t, err)
-	require.Equal(t, testIotaAddress, signer.Address())
-	signer, err = iotasigner.NewSignerWithMnemonic(testcommon.TestMnemonic, iotasigner.KeySchemeFlagEd25519)
+	signer, err := iotasigner.NewSignerWithMnemonic(testcommon.TestMnemonic, iotasigner.KeySchemeFlagDefault)
 	require.NoError(t, err)
 	require.Equal(t, iotago.MustAddressFromHex(testcommon.TestAddress), signer.Address())
 }

--- a/clients/iota-go/iotatest/faucet.go
+++ b/clients/iota-go/iotatest/faucet.go
@@ -13,7 +13,7 @@ func MakeSignerWithFunds(index int, faucetURL string) iotasigner.Signer {
 }
 
 func MakeSignerWithFundsFromSeed(seed []byte, index int, faucetURL string) iotasigner.Signer {
-	keySchemeFlag := iotasigner.KeySchemeFlagIotaEd25519
+	keySchemeFlag := iotasigner.KeySchemeFlagDefault
 
 	// there are only 256 different signers can be generated
 	signer := iotasigner.NewSignerByIndex(seed, keySchemeFlag, index)

--- a/clients/iota-go/test_common/consts.go
+++ b/clients/iota-go/test_common/consts.go
@@ -2,7 +2,40 @@ package testcommon
 
 const (
 	TestMnemonic = "ordinary cry margin host traffic bulb start zone mimic wage fossil eight diagram clay say remove add atom"
-	TestAddress  = "0xe54d993cf56be93ba0764c7ee2c817085b70f0e6d3ad1a71c3335ee3529b4a48"
+	TestAddress  = "0x786dff8a4ee13d45b502c8f22f398e3517e6ec78aa4ae564c348acb07fad7f50"
 )
 
-var TestSeed = []byte{50, 230, 119, 9, 86, 155, 106, 30, 245, 81, 234, 122, 116, 90, 172, 148, 59, 33, 88, 252, 134, 42, 231, 198, 208, 141, 209, 116, 78, 21, 216, 24}
+var TestSeed = []byte{
+	50,
+	230,
+	119,
+	9,
+	86,
+	155,
+	106,
+	30,
+	245,
+	81,
+	234,
+	122,
+	116,
+	90,
+	172,
+	148,
+	59,
+	33,
+	88,
+	252,
+	134,
+	42,
+	231,
+	198,
+	208,
+	141,
+	209,
+	116,
+	78,
+	21,
+	216,
+	24,
+}

--- a/packages/cryptolib/compatability_test.go
+++ b/packages/cryptolib/compatability_test.go
@@ -18,7 +18,7 @@ func TestCompatability(t *testing.T) {
 
 	kp := KeyPairFromSeed(SubSeed(seed, seedIndex))
 	subseed := SubSeed(seed, seedIndex)
-	suikp := iotasigner.NewSigner(subseed[:], iotasigner.KeySchemeFlagIotaEd25519)
+	suikp := iotasigner.NewSigner(subseed[:], iotasigner.KeySchemeFlagDefault)
 
 	require.Equal(t, kp.Address().AsIotaAddress().Data(), suikp.Address().Data())
 

--- a/packages/cryptolib/seed.go
+++ b/packages/cryptolib/seed.go
@@ -2,17 +2,14 @@ package cryptolib
 
 import (
 	"crypto/ed25519"
-	"encoding/binary"
 
 	"github.com/wollac/iota-crypto-demo/pkg/bip32path"
 	"github.com/wollac/iota-crypto-demo/pkg/slip10"
 	"github.com/wollac/iota-crypto-demo/pkg/slip10/eddsa"
-	"golang.org/x/crypto/blake2b"
 
 	hivecrypto "github.com/iotaledger/hive.go/crypto/ed25519"
 
 	"github.com/iotaledger/wasp/clients/iota-go/iotasigner"
-	"github.com/iotaledger/wasp/packages/cryptolib/byteutils"
 )
 
 // testnet/alphanet uses COIN_TYPE = 1
@@ -23,12 +20,7 @@ const IotaCoinType = iotasigner.IotaCoinType
 
 // SubSeed returns a Seed (ed25519 Seed) from a master seed (that has arbitrary length)
 // note that the accountIndex is actually an uint31
-func SubSeed(walletSeed []byte, accountIndex uint32, useLegacyDerivation ...bool) Seed {
-	if len(useLegacyDerivation) > 0 && useLegacyDerivation[0] {
-		seed := SeedFromBytes(walletSeed)
-		return legacyDerivation(&seed, accountIndex)
-	}
-
+func SubSeed(walletSeed []byte, accountIndex uint32) Seed {
 	bip32Path, err := iotasigner.BuildBip32Path(iotasigner.SignatureFlagEd25519, iotasigner.IotaCoinType, accountIndex)
 	if err != nil {
 		panic(err)
@@ -63,13 +55,4 @@ func NewSeed() (ret Seed) {
 func SeedFromBytes(data []byte) (ret Seed) {
 	copy(ret[:], data)
 	return ret
-}
-
-func legacyDerivation(seed *Seed, index uint32) Seed {
-	subSeed := make([]byte, SeedSize)
-	indexBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint32(indexBytes[:4], index)
-	hashOfIndexBytes := blake2b.Sum256(indexBytes)
-	byteutils.XORBytes(subSeed, seed[:], hashOfIndexBytes[:])
-	return SeedFromBytes(subSeed)
 }

--- a/tools/wasp-cli/cli/wallet/providers/keychain.go
+++ b/tools/wasp-cli/cli/wallet/providers/keychain.go
@@ -31,8 +31,7 @@ func LoadKeyChain(addressIndex uint32) wallets.Wallet {
 	seed, err := config.GetKeyChain().GetSeed()
 	log.Check(err)
 
-	useLegacyDerivation := config.GetUseLegacyDerivation()
-	keyPair := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(seed[:], addressIndex, useLegacyDerivation))
+	keyPair := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(seed[:], addressIndex))
 
 	return newInMemoryWallet(keyPair, addressIndex)
 }

--- a/tools/wasp-cli/cli/wallet/providers/unsafe_inmemory_seed.go
+++ b/tools/wasp-cli/cli/wallet/providers/unsafe_inmemory_seed.go
@@ -29,8 +29,7 @@ func LoadUnsafeInMemoryTestingSeed(addressIndex uint32) wallets.Wallet {
 	seed, err := hexutil.Decode(config.GetTestingSeed())
 	log.Check(err)
 
-	useLegacyDerivation := config.GetUseLegacyDerivation()
-	keyPair := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(seed, addressIndex, useLegacyDerivation))
+	keyPair := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(seed, addressIndex))
 
 	return NewUnsafeInMemoryTestingSeed(keyPair, addressIndex)
 }

--- a/tools/wasp-cli/cli/wallet/wallet.go
+++ b/tools/wasp-cli/cli/wallet/wallet.go
@@ -76,7 +76,6 @@ func Load() wallets.Wallet {
 		switch walletProvider {
 		case ProviderLedger, ProviderLedgerDebug:
 			loadedWallet = providers.NewExternalWallet(initializeLedger(walletProvider), AddressIndex, iotasigner.IotaCoinType)
-
 		case ProviderKeyChain:
 			loadedWallet = providers.LoadKeyChain(AddressIndex)
 		case ProviderUnsafeInMemoryTestingSeed:


### PR DESCRIPTION
- Secp256k1 removed from `NewSigner` as it's unsupported and unused. 
- Discussed removing Ed25519 as well but it is used by `hw_ledger` package