### PR TITLE
chore: fix incompatible changes

### DIFF
--- a/packages/solo/ledgerl1l2.go
+++ b/packages/solo/ledgerl1l2.go
@@ -67,7 +67,12 @@ func (ch *Chain) L2AssetsAtStateIndex(agentID isc.AgentID, stateIndex uint32) *i
 
 	cb := lo.Must(accounts.ViewBalance.DecodeOutput(res))
 
-	return cb
+	assets := isc.NewEmptyAssets()
+	for coinType, balance := range cb.Iterate() {
+		assets.AddCoin(coinType, balance)
+	}
+
+	return assets
 }
 
 func (ch *Chain) L2BaseTokens(agentID isc.AgentID) coin.Value {
@@ -104,7 +109,14 @@ func (ch *Chain) L2CommonAccountNativeTokens(coinType coin.Type) coin.Value {
 func (ch *Chain) L2TotalAssets() *isc.Assets {
 	r, err := ch.CallView(accounts.ViewTotalAssets.Message())
 	require.NoError(ch.Env.T, err)
-	return lo.Must(accounts.ViewTotalAssets.DecodeOutput(r))
+	cb := lo.Must(accounts.ViewTotalAssets.DecodeOutput(r))
+
+	assets := isc.NewEmptyAssets()
+	for coinType, balance := range cb.Iterate() {
+		assets.AddCoin(coinType, balance)
+	}
+
+	return assets
 }
 
 // L2TotalBaseTokens return total sum of base tokens in L2 (all accounts)

--- a/packages/vm/core/accounts/impl_views.go
+++ b/packages/vm/core/accounts/impl_views.go
@@ -9,10 +9,10 @@ import (
 )
 
 // viewBalance returns the balances of the account belonging to the AgentID
-func viewBalance(ctx isc.SandboxView, optionalAgentID *isc.AgentID) *isc.Assets {
+func viewBalance(ctx isc.SandboxView, optionalAgentID *isc.AgentID) isc.CoinBalances {
 	aid := coreutil.FromOptional(optionalAgentID, ctx.Caller())
 	ctx.Log().Debugf("accounts.viewBalance %s", aid)
-	return NewStateReaderFromSandbox(ctx).GetAssets(aid)
+	return NewStateReaderFromSandbox(ctx).getFungibleTokens(accountKey(aid))
 }
 
 // viewBalanceBaseToken returns the base tokens balance of the account belonging to the AgentID
@@ -36,9 +36,9 @@ func viewBalanceCoin(ctx isc.SandboxView, optionalAgentID *isc.AgentID, coinID c
 }
 
 // viewTotalAssets returns total balances controlled by the chain
-func viewTotalAssets(ctx isc.SandboxView) *isc.Assets {
+func viewTotalAssets(ctx isc.SandboxView) isc.CoinBalances {
 	ctx.Log().Debugf("accounts.viewTotalAssets")
-	return NewStateReaderFromSandbox(ctx).GetTotalAssets()
+	return NewStateReaderFromSandbox(ctx).getFungibleTokens(L2TotalsAccount)
 }
 
 // nonces are only sent with off-ledger requests

--- a/packages/vm/core/accounts/interface.go
+++ b/packages/vm/core/accounts/interface.go
@@ -50,7 +50,7 @@ var (
 	// TODO: implement pagination
 	ViewBalance = coreutil.NewViewEP11(Contract, "balance",
 		coreutil.FieldOptional[isc.AgentID]("agentID"),
-		coreutil.Field[*isc.Assets]("coinBalances"),
+		coreutil.Field[isc.CoinBalances]("coinBalances"),
 	)
 	ViewBalanceBaseToken = coreutil.NewViewEP11(Contract, "balanceBaseToken",
 		coreutil.FieldOptional[isc.AgentID]("agentID"),
@@ -72,6 +72,6 @@ var (
 	)
 	// TODO: implement pagination
 	ViewTotalAssets = coreutil.NewViewEP01(Contract, "totalAssets",
-		coreutil.Field[*isc.Assets]("coinBalances"),
+		coreutil.Field[isc.CoinBalances]("coinBalances"),
 	)
 )

--- a/packages/vm/core/blocklog/blockinfo.go
+++ b/packages/vm/core/blocklog/blockinfo.go
@@ -18,12 +18,9 @@ import (
 
 const (
 	blockInfoSchemaVersion0 = iota
-	blockInfoSchemaVersion1NOOP
-	blockInfoSchemaVersion2NOOP
-	blockInfoSchemaVersion3NOOP
-	blockInfoSchemaVersion4NOOP
-	blockInfoSchemaVersion5NOOP
-	blockInfoSchemaVersionAddedEntropy
+	// During migration, the block info schema version was incorrectly set to 5 instead of 0.
+	// To support additional changes, we now have to start with schema version 6.
+	blockInfoSchemaVersionAddedEntropy = iota + 5
 
 	BlockInfoLatestSchemaVersion = blockInfoSchemaVersionAddedEntropy
 )

--- a/packages/vm/core/blocklog/blockinfo.go
+++ b/packages/vm/core/blocklog/blockinfo.go
@@ -18,6 +18,11 @@ import (
 
 const (
 	blockInfoSchemaVersion0 = iota
+	blockInfoSchemaVersion1NOOP
+	blockInfoSchemaVersion2NOOP
+	blockInfoSchemaVersion3NOOP
+	blockInfoSchemaVersion4NOOP
+	blockInfoSchemaVersion5NOOP
 	blockInfoSchemaVersionAddedEntropy
 
 	BlockInfoLatestSchemaVersion = blockInfoSchemaVersionAddedEntropy

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -1841,7 +1841,7 @@ func TestCaller(t *testing.T) {
 	var r []byte
 	err = iscTest.callView("testCallViewCaller", nil, &r)
 	require.NoError(t, err)
-	require.EqualValues(t, 42, lo.Must(isc.AssetsFromBytes(r)).BaseTokens())
+	require.EqualValues(t, 42, lo.Must(isc.CoinBalancesFromBytes(r)).BaseTokens())
 }
 
 func TestCustomError(t *testing.T) {

--- a/packages/webapi/corecontracts/accounts.go
+++ b/packages/webapi/corecontracts/accounts.go
@@ -13,7 +13,21 @@ func GetTotalAssets(ch chain.Chain, blockIndexOrTrieRoot string) (*isc.Assets, e
 	if err != nil {
 		return nil, err
 	}
-	return accounts.ViewTotalAssets.DecodeOutput(ret)
+
+	coinBalances, err := accounts.ViewTotalAssets.DecodeOutput(ret)
+	if err != nil {
+		return nil, err
+	}
+
+	assets := isc.NewEmptyAssets()
+	for coinType, balance := range coinBalances.Iterate() {
+		assets.AddCoin(coinType, balance)
+	}
+
+	// Objects currently unsupported
+	// TODO: Create some kind of ViewTotalObjects function and map both.
+
+	return assets, nil
 }
 
 func GetAccountBalance(ch chain.Chain, agentID isc.AgentID, blockIndexOrTrieRoot string) (*isc.Assets, error) {
@@ -21,7 +35,21 @@ func GetAccountBalance(ch chain.Chain, agentID isc.AgentID, blockIndexOrTrieRoot
 	if err != nil {
 		return nil, err
 	}
-	return accounts.ViewBalance.DecodeOutput(ret)
+
+	coinBalances, err := accounts.ViewBalance.DecodeOutput(ret)
+	if err != nil {
+		return nil, err
+	}
+
+	assets := isc.NewEmptyAssets()
+	for coinType, balance := range coinBalances.Iterate() {
+		assets.AddCoin(coinType, balance)
+	}
+
+	// Objects currently unsupported
+	// TODO: Create some kind of ViewObjects function and map both.
+
+	return assets, nil
 }
 
 func GetAccountObjects(ch chain.Chain, agentID isc.AgentID, blockIndexOrTrieRoot string) ([]isc.IotaObject, error) {


### PR DESCRIPTION
Fixes:

* Block version had to be set to 6 instead of 1
* isc.Assets has been reverted back to CoinBalances 
  * WebAPI was changed to accommodate the type, but does not support returning objects 