### PR TITLE
fix: Improve wasp-cli error handling

### DIFF
--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -200,10 +200,6 @@ func initDepositCmd() *cobra.Command {
 						},
 					)
 				})
-
-				if err != nil {
-					return err
-				}
 			}
 
 			if printReceipt {

--- a/tools/wasp-cli/chain/activate.go
+++ b/tools/wasp-cli/chain/activate.go
@@ -44,7 +44,6 @@ func initActivateCmd() *cobra.Command {
 func activateChain(ctx context.Context, node string, chainName string, chainID isc.ChainID) {
 	client := cliclients.WaspClientWithVersionCheck(ctx, node)
 	r, httpStatus, err := client.ChainsAPI.GetChainInfo(ctx).Execute() //nolint:bodyclose // false positive
-
 	if err != nil && httpStatus.StatusCode != http.StatusNotFound {
 		log.Check(err)
 	}
@@ -58,7 +57,6 @@ func activateChain(ctx context.Context, node string, chainName string, chainID i
 			IsActive:    true,
 			AccessNodes: []string{},
 		}).Execute() //nolint:bodyclose // false positive
-
 		log.Check(err2)
 	} else {
 		_, err = client.ChainsAPI.ActivateChain(ctx, chainID.String()).Execute() //nolint:bodyclose // false positive

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -139,8 +139,9 @@ func initializeDeploymentWithGasCoin(ctx context.Context, signer wallets.Wallet,
 
 	client := cliclients.WaspClientWithVersionCheck(ctx, node)
 	_, header, err := client.ChainsAPI.GetChainInfo(ctx).Execute()
-	defer header.Body.Close()
-
+	if header != nil && header.Body != nil {
+		defer header.Body.Close()
+	}
 	// We expect a 404 if no chain has been deployed yet. In any other case, show the error.
 	if err != nil && !strings.Contains(err.Error(), strconv.Itoa(http.StatusNotFound)) {
 		return nil, fmt.Errorf("failed to get current chain info: %w", err)

--- a/tools/wasp-cli/chain/info.go
+++ b/tools/wasp-cli/chain/info.go
@@ -38,14 +38,12 @@ func initInfoCmd() *cobra.Command { //nolint:funlen
 			chainInfo, res, err := client.ChainsAPI.
 				GetChainInfo(ctx).
 				Execute() //nolint:bodyclose // false positive
-
+			if err != nil {
+				return err
+			}
 			if res.StatusCode == http.StatusNotFound {
 				fmt.Print("No chain info available. Is the chain deployed and activated?\n")
 				return nil
-			}
-
-			if err != nil {
-				return err
 			}
 
 			committeeInfo, _, err := client.ChainsAPI.

--- a/tools/wasp-cli/cli/keychain/keychain_file.go
+++ b/tools/wasp-cli/cli/keychain/keychain_file.go
@@ -141,8 +141,7 @@ func (k *KeyChainFile) Set(key string, value []byte) error {
 }
 
 func (k *KeyChainFile) SetSeed(seed cryptolib.Seed) error {
-	err := k.Set(seedKey, seed[:])
-	return err
+	return k.Set(seedKey, seed[:])
 }
 
 func (k *KeyChainFile) GetSeed() (*cryptolib.Seed, error) {

--- a/tools/wasp-cli/codec/cmd.go
+++ b/tools/wasp-cli/codec/cmd.go
@@ -117,9 +117,8 @@ func initDecodeWALCmd() *cobra.Command {
 				}
 			}
 
-			receipts, err := blocklog.RequestReceiptsFromBlock(block)
 			fmt.Printf("\nRequests:\n\n")
-
+			receipts, err := blocklog.RequestReceiptsFromBlock(block)
 			if err != nil {
 				fmt.Println("Failed to decode receipts")
 				fmt.Println(err)

--- a/tools/wasp-cli/peering/distrust.go
+++ b/tools/wasp-cli/peering/distrust.go
@@ -48,7 +48,6 @@ func initDistrustCmd() *cobra.Command {
 			for _, t := range trustedList {
 				if t.PublicKey == input {
 					_, err := client.NodeAPI.DistrustPeer(ctx, t.PublicKey).Execute()
-
 					if err != nil {
 						log.Printf("error: failed to distrust %v/%v, reason=%v\n", t.PublicKey, t.PeeringURL, err)
 					} else {


### PR DESCRIPTION
Improve the unintentional nil dereference, and make the error handling comes right after the error returns. 