### PR TITLE
Refactor cobra commands to return errors

### DIFF
--- a/tools/cluster/tests/wasp-cli_test.go
+++ b/tools/cluster/tests/wasp-cli_test.go
@@ -39,7 +39,7 @@ func TestWaspAuth(t *testing.T) {
 
 	t.Run("table format output", func(t *testing.T) {
 		// t.Skip()
-		out := w.MustRun("auth", "login", "--node=0", "-u=wasp", "-p=wasp")
+		out := w.MustRun("auth", "login", "--node=0", "-u=wasp", "-p=wasp", "--table")
 		// Check for table output format with SUCCESS status
 		found := false
 		for _, line := range out {
@@ -71,25 +71,22 @@ func TestWaspAuth(t *testing.T) {
 		require.Contains(t, authResult, "type", "JSON output should contain 'type' field")
 		require.Contains(t, authResult, "status", "JSON output should contain 'status' field")
 		require.Contains(t, authResult, "timestamp", "JSON output should contain 'timestamp' field")
-		require.Contains(t, authResult, "data", "JSON output should contain 'data' field")
 
 		// Verify top-level field values
 		require.Equal(t, "auth", authResult["type"], "Expected type to be 'auth'")
 		require.Equal(t, "success", authResult["status"], "Expected status to be 'success'")
 		require.NotEmpty(t, authResult["timestamp"], "Timestamp should not be empty")
 
-		// Verify the data structure contains auth-specific fields
-		data, ok := authResult["data"].(map[string]interface{})
-		require.True(t, ok, "Data field should be an object")
-		require.Contains(t, data, "node", "Auth data should contain 'node' field")
-		require.Contains(t, data, "username", "Auth data should contain 'username' field")
+		// Verify auth-specific fields are at the top level (no data wrapper)
+		require.Contains(t, authResult, "node", "Auth result should contain 'node' field")
+		require.Contains(t, authResult, "username", "Auth result should contain 'username' field")
 
-		// Verify the auth data values are correct
-		require.Equal(t, "0", data["node"], "Expected node to be '0'")
-		require.Equal(t, "wasp", data["username"], "Expected username to be 'wasp'")
+		// Verify the auth values are correct
+		require.Equal(t, "0", authResult["node"], "Expected node to be '0'")
+		require.Equal(t, "wasp", authResult["username"], "Expected username to be 'wasp'")
 
-		// Check if the message field exists in data (it's optional)
-		if message, exists := data["message"]; exists {
+		// Check if the message field exists (it's optional)
+		if message, exists := authResult["message"]; exists {
 			require.NotEmpty(t, message, "Message field should not be empty if present")
 		}
 

--- a/tools/wasp-cli/chain/access-nodes.go
+++ b/tools/wasp-cli/chain/access-nodes.go
@@ -6,6 +6,7 @@ package chain
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -29,7 +30,10 @@ func initPermissionlessAccessNodesCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 
 			action := args[0]
 			node, err = waspcmd.DefaultWaspNodeFallback(node)
@@ -39,31 +43,39 @@ func initPermissionlessAccessNodesCmd() *cobra.Command {
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 
-			var executeActionFunc func(peer string)
+			var executeActionFunc func(peer string) error
 
 			switch action {
 			case "add":
-				executeActionFunc = func(peer string) {
+				executeActionFunc = func(peer string) error {
 					_, err := client.ChainsAPI.
 						AddAccessNode(ctx, peer).
 						Execute() //nolint:bodyclose // false positive
-					log.Check(err)
+					if err != nil {
+						return err
+					}
 					log.Printf("added %s as an access node\n", peer)
+					return nil
 				}
 			case "remove":
-				executeActionFunc = func(peer string) {
+				executeActionFunc = func(peer string) error {
 					_, err := client.ChainsAPI.
 						RemoveAccessNode(ctx, peer).
 						Execute() //nolint:bodyclose // false positive
-					log.Check(err)
+					if err != nil {
+						return err
+					}
 					log.Printf("removed %s as an access node\n", peer)
+					return nil
 				}
 			default:
-				log.Fatalf("unknown action: %s", action)
+				return fmt.Errorf("unknown action: %s", action)
 			}
 
 			for _, peer := range peers {
-				executeActionFunc(peer)
+				if err := executeActionFunc(peer); err != nil {
+					return err
+				}
 			}
 			return nil
 		},

--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -82,7 +82,10 @@ func initAccountObjectsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			agentID := util.AgentIDFromArgs(args)
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
@@ -154,7 +157,10 @@ func initDepositCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			chainID := config.GetChain(chain)
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*1000)

--- a/tools/wasp-cli/chain/activate.go
+++ b/tools/wasp-cli/chain/activate.go
@@ -27,7 +27,10 @@ func initActivateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chainName = defaultChainFallback(chainName)
+			chainName, err = defaultChainFallback(chainName)
+			if err != nil {
+				return err
+			}
 			chainID := config.GetChain(chainName)
 			ctx := context.Background()
 			activateChain(ctx, node, chainName, chainID)
@@ -75,9 +78,11 @@ func initDeactivateCmd() *cobra.Command {
 		Short: "Deactivates the chain on selected nodes",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chainName = defaultChainFallback(chainName)
-
 			var err error
+			chainName, err = defaultChainFallback(chainName)
+			if err != nil {
+				return err
+			}
 			node, err = waspcmd.DefaultWaspNodeFallback(node)
 			if err != nil {
 				return err

--- a/tools/wasp-cli/chain/blocklog.go
+++ b/tools/wasp-cli/chain/blocklog.go
@@ -33,20 +33,30 @@ func initBlockCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 
-			bi := fetchBlockInfo(ctx, client, args)
+			bi, err := fetchBlockInfo(ctx, client, args)
+			if err != nil {
+				return err
+			}
 			log.Printf("Block index: %d\n", bi.BlockIndex)
 			log.Printf("Timestamp: %s\n", bi.Timestamp.UTC().Format(time.RFC3339))
 			log.Printf("Total requests: %d\n", bi.TotalRequests)
 			log.Printf("Successful requests: %d\n", bi.NumSuccessfulRequests)
 			log.Printf("Off-ledger requests: %d\n", bi.NumOffLedgerRequests)
 			log.Printf("\n")
-			logRequestsInBlock(ctx, client, bi.BlockIndex)
+			if err := logRequestsInBlock(ctx, client, bi.BlockIndex); err != nil {
+				return err
+			}
 			log.Printf("\n")
-			logEventsInBlock(ctx, client, bi.BlockIndex)
+			if err := logEventsInBlock(ctx, client, bi.BlockIndex); err != nil {
+				return err
+			}
 			return nil
 		},
 	}
@@ -55,76 +65,87 @@ func initBlockCmd() *cobra.Command {
 	return cmd
 }
 
-func fetchBlockInfo(ctx context.Context, client *apiclient.APIClient, args []string) *apiclient.BlockInfoResponse {
+func fetchBlockInfo(ctx context.Context, client *apiclient.APIClient, args []string) (*apiclient.BlockInfoResponse, error) {
 	if len(args) == 0 {
 		blockInfo, _, err := client.
 			CorecontractsAPI.
 			BlocklogGetLatestBlockInfo(ctx).
 			Execute() //nolint:bodyclose // false positive
-
-		log.Check(err)
-		return blockInfo
+		if err != nil {
+			return nil, err
+		}
+		return blockInfo, nil
 	}
 
 	blockIndexStr := args[0]
 	index, err := strconv.ParseUint(blockIndexStr, 10, 32)
-	log.Check(err)
+	if err != nil {
+		return nil, fmt.Errorf("invalid block index '%s': %w", blockIndexStr, err)
+	}
 
 	blockInfo, _, err := client.
 		CorecontractsAPI.
 		BlocklogGetBlockInfo(ctx, uint32(index)).
 		Block(blockIndexStr).
 		Execute() //nolint:bodyclose // false positive
-
-	log.Check(err)
-	return blockInfo
+	if err != nil {
+		return nil, err
+	}
+	return blockInfo, nil
 }
 
-func logRequestsInBlock(ctx context.Context, client *apiclient.APIClient, index uint32) {
+func logRequestsInBlock(ctx context.Context, client *apiclient.APIClient, index uint32) error {
 	receipts, _, err := client.CorecontractsAPI.
 		BlocklogGetRequestReceiptsOfBlock(ctx, index).
 		Block(fmt.Sprintf("%d", index)).
 		Execute() //nolint:bodyclose // false positive
-
-	log.Check(err)
+	if err != nil {
+		return err
+	}
 
 	for i, receipt := range receipts {
 		r := receipt
 		util.LogReceipt(r, i)
 	}
+	return nil
 }
 
-func logEventsInBlock(ctx context.Context, client *apiclient.APIClient, index uint32) {
+func logEventsInBlock(ctx context.Context, client *apiclient.APIClient, index uint32) error {
 	events, _, err := client.CorecontractsAPI.
 		BlocklogGetEventsOfBlock(ctx, index).
 		Block(fmt.Sprintf("%d", index)).
 		Execute() //nolint:bodyclose // false positive
-
-	log.Check(err)
+	if err != nil {
+		return err
+	}
 	logEvents(events)
+	return nil
 }
 
 func hexLenFromByteLen(length int) int {
 	return (length * 2) + 2
 }
 
-func reqIDFromString(s string) isc.RequestID {
+func reqIDFromString(s string) (isc.RequestID, error) {
 	switch len(s) {
 	case hexLenFromByteLen(iotago.AddressLen):
 		// isc ReqID
 		reqID, err := isc.RequestIDFromString(s)
-		log.Check(err)
-		return reqID
+		if err != nil {
+			return isc.RequestID{}, fmt.Errorf("invalid isc requestID: %w", err)
+		}
+		return reqID, nil
 	case hexLenFromByteLen(common.HashLength):
 		bytes, err := cryptolib.DecodeHex(s)
-		log.Check(err)
+		if err != nil {
+			return isc.RequestID{}, fmt.Errorf("invalid evm tx hash: %w", err)
+		}
 		var txHash common.Hash
 		copy(txHash[:], bytes)
-		return isc.RequestIDFromEVMTxHash(txHash)
+		return isc.RequestIDFromEVMTxHash(txHash), nil
 	default:
-		log.Fatalf("invalid requestID length: %d", len(s))
+		return isc.RequestID{}, fmt.Errorf("invalid requestID length: %d", len(s))
 	}
-	panic("unreachable")
 }
 
 func initRequestCmd() *cobra.Command {
@@ -140,11 +161,17 @@ func initRequestCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 
-			reqID := reqIDFromString(args[0])
+			reqID, err := reqIDFromString(args[0])
+			if err != nil {
+				return err
+			}
 
 			// TODO add optional block param?
 			receipt, _, err := client.ChainsAPI.
@@ -158,7 +185,9 @@ func initRequestCmd() *cobra.Command {
 			util.LogReceipt(*receipt)
 
 			log.Printf("\n")
-			logEventsInRequest(ctx, client, reqID)
+			if err := logEventsInRequest(ctx, client, reqID); err != nil {
+				return err
+			}
 			log.Printf("\n")
 			return nil
 		},
@@ -168,13 +197,15 @@ func initRequestCmd() *cobra.Command {
 	return cmd
 }
 
-func logEventsInRequest(ctx context.Context, client *apiclient.APIClient, reqID isc.RequestID) {
+func logEventsInRequest(ctx context.Context, client *apiclient.APIClient, reqID isc.RequestID) error {
 	events, _, err := client.CorecontractsAPI.
 		BlocklogGetEventsOfRequest(ctx, reqID.String()).
 		Execute() //nolint:bodyclose // false positive
-
-	log.Check(err)
+	if err != nil {
+		return err
+	}
 	logEvents(events)
+	return nil
 }
 
 func logEvents(ret *apiclient.EventsResponse) {

--- a/tools/wasp-cli/chain/callview.go
+++ b/tools/wasp-cli/chain/callview.go
@@ -27,7 +27,10 @@ func initCallViewCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -206,7 +206,10 @@ func initDeployCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chainName = defaultChainFallback(chainName)
+			chainName, err = defaultChainFallback(chainName)
+			if err != nil {
+				return err
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
 

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -45,18 +45,21 @@ func initDeployMoveContractCmd() *cobra.Command {
 		Use:   "deploy-move-contract",
 		Short: "Deploy a new move contract and save its package id",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
 
 			l1Client := cliclients.L1Client()
 			kp := wallet.Load()
 			packageID, err := l1Client.DeployISCContracts(ctx, cryptolib.SignerToIotaSigner(kp))
-			log.Check(err)
+			if err != nil {
+				return err
+			}
 
 			config.SetPackageID(packageID)
 
 			log.Printf("Move contract deployed.\nPackageID: %v\n", packageID.String())
+			return nil
 		},
 	}
 

--- a/tools/wasp-cli/chain/flag.go
+++ b/tools/wasp-cli/chain/flag.go
@@ -1,8 +1,9 @@
 package chain
 
 import (
+	"fmt"
+
 	"github.com/iotaledger/wasp/v2/tools/wasp-cli/cli/config"
-	"github.com/iotaledger/wasp/v2/tools/wasp-cli/log"
 	"github.com/spf13/cobra"
 )
 
@@ -10,14 +11,14 @@ func withChainFlag(cmd *cobra.Command, chainName *string) {
 	cmd.Flags().StringVar(chainName, "chain", "", "target chain name")
 }
 
-func defaultChainFallback(chainName string) string {
+func defaultChainFallback(chainName string) (string, error) {
 	if chainName != "" {
-		return chainName
+		return chainName, nil
 	}
 	return getDefaultChain()
 }
 
-func getDefaultChain() string {
+func getDefaultChain() (string, error) {
 	chainSettings := map[string]interface{}{}
 	chainsKey := config.Config.Cut("chains")
 	if chainsKey != nil {
@@ -25,13 +26,13 @@ func getDefaultChain() string {
 	}
 	switch len(chainSettings) {
 	case 0:
-		log.Fatalf("no chains configured, you can add a new chain with `wasp-cli chain add <name> <chain id>`")
+		return "", fmt.Errorf("no chains configured, you can add a new chain with `wasp-cli chain add <name> <chain id>`")
 	case 1:
 		for nodeName := range chainSettings {
-			return nodeName
+			return nodeName, nil
 		}
 	default:
-		log.Fatalf("more than 1 chain in the configuration, you can specify the target chain with `--chain=<name>`")
+		return "", fmt.Errorf("more than 1 chain in the configuration, you can specify the target chain with `--chain=<name>`")
 	}
-	panic("unreachable")
+	return "", nil
 }

--- a/tools/wasp-cli/chain/governance.go
+++ b/tools/wasp-cli/chain/governance.go
@@ -38,7 +38,10 @@ func initChangeAccessNodesCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 			if len(args)%2 != 0 {
@@ -106,7 +109,10 @@ func initDisableFeePolicyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 

--- a/tools/wasp-cli/chain/import-chain.go
+++ b/tools/wasp-cli/chain/import-chain.go
@@ -68,6 +68,87 @@ func openChainAndRead(dbPath string) (transaction.StateMetadata, uint32, error) 
 	return anchorStateMetadata, latestBlock.StateIndex(), nil
 }
 
+func runImportChain(dbPath string, node string, peers []string, quorum int, chainName string) error {
+	var err error
+	// resolve defaults
+	node, err = waspcmd.DefaultWaspNodeFallback(node)
+	if err != nil {
+		return err
+	}
+	chainName, err = defaultChainFallback(chainName)
+	if err != nil {
+		return err
+	}
+	kp := wallet.Load()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	result, err := initializeDeploymentWithGasCoin(ctx, kp, node, chainName, peers, quorum)
+	if err != nil {
+		return err
+	}
+
+	anchorStateMetadata, blockIndex, err := openChainAndRead(dbPath)
+	if err != nil {
+		return err
+	}
+	anchorStateMetadata.GasCoinObjectID = &result.gasCoinObject
+
+	anchor, err := cliclients.L2Client().StartNewChain(ctx, &iscmoveclient.StartNewChainRequest{
+		PackageID:     config.GetPackageID(),
+		AnchorOwner:   kp.Address(),
+		Signer:        kp,
+		GasPrice:      iotaclient.DefaultGasPrice,
+		GasBudget:     iotaclient.DefaultGasBudget,
+		StateMetadata: make([]byte, 0),
+		InitCoinRef:   nil,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = cliclients.L2Client().UpdateAnchorStateMetadata(ctx, &iscmoveclient.UpdateAnchorStateMetadataRequest{
+		StateIndex:    blockIndex,
+		StateMetadata: anchorStateMetadata.Bytes(),
+		Signer:        kp,
+		GasPrice:      iotaclient.DefaultGasPrice,
+		GasBudget:     iotaclient.DefaultGasBudget,
+		PackageID:     config.GetPackageID(),
+		AnchorRef:     &anchor.ObjectRef,
+	})
+	if err != nil {
+		return err
+	}
+
+	transferAnchor, err := cliclients.L1Client().TransferObject(ctx, iotaclient.TransferObjectRequest{
+		Signer:    kp.Address().AsIotaAddress(),
+		ObjectID:  anchor.ObjectID,
+		Recipient: result.committeeAddress.AsIotaAddress(),
+		GasBudget: iotajsonrpc.NewBigInt(iotaclient.DefaultGasBudget),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to construct transfer anchor: %w", err)
+	}
+
+	_, err = cliclients.L1Client().SignAndExecuteTransaction(ctx, &iotaclient.SignAndExecuteTransactionRequest{
+		Signer:      cryptolib.SignerToIotaSigner(kp),
+		TxDataBytes: transferAnchor.TxBytes,
+		Options: &iotajsonrpc.IotaTransactionBlockResponseOptions{
+			ShowObjectChanges: true,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to execute transfer anchor: %w", err)
+	}
+	config.AddChain(chainName, anchor.ObjectID.String())
+
+	fmt.Printf("\nChain has been deployed.\nID: %s\nStateMetadata: %v\n", anchor.ObjectID.String(), anchorStateMetadata)
+	fmt.Printf("Create the following path: './waspdb/chains/data/%s' and move or link the chain files into it.\n", anchor.ObjectID.String())
+	fmt.Println("Then call `chain activate` to finalize the deployment.")
+	return nil
+}
+
 func initImportCmd() *cobra.Command {
 	var (
 		node      string
@@ -84,81 +165,7 @@ func initImportCmd() *cobra.Command {
 			"After the deployment succeeded, you will need to either link or move the wasp chain files into 'waspdb/chains/data/<chainID>' and call 'chain activate'",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			node, err = waspcmd.DefaultWaspNodeFallback(node)
-			if err != nil {
-				return err
-			}
-			chainName = defaultChainFallback(chainName)
-			kp := wallet.Load()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-			defer cancel()
-
-			result, err := initializeDeploymentWithGasCoin(ctx, kp, node, chainName, peers, quorum)
-			if err != nil {
-				return err
-			}
-
-			dbPath := args[0]
-			anchorStateMetadata, blockIndex, err := openChainAndRead(dbPath)
-			if err != nil {
-				return err
-			}
-			anchorStateMetadata.GasCoinObjectID = &result.gasCoinObject
-
-			anchor, err := cliclients.L2Client().StartNewChain(ctx, &iscmoveclient.StartNewChainRequest{
-				PackageID:     config.GetPackageID(),
-				AnchorOwner:   kp.Address(),
-				Signer:        kp,
-				GasPrice:      iotaclient.DefaultGasPrice,
-				GasBudget:     iotaclient.DefaultGasBudget,
-				StateMetadata: make([]byte, 0),
-				InitCoinRef:   nil,
-			})
-			if err != nil {
-				return err
-			}
-
-			_, err = cliclients.L2Client().UpdateAnchorStateMetadata(ctx, &iscmoveclient.UpdateAnchorStateMetadataRequest{
-				StateIndex:    blockIndex,
-				StateMetadata: anchorStateMetadata.Bytes(),
-				Signer:        kp,
-				GasPrice:      iotaclient.DefaultGasPrice,
-				GasBudget:     iotaclient.DefaultGasBudget,
-				PackageID:     config.GetPackageID(),
-				AnchorRef:     &anchor.ObjectRef,
-			})
-			if err != nil {
-				return err
-			}
-
-			transferAnchor, err := cliclients.L1Client().TransferObject(ctx, iotaclient.TransferObjectRequest{
-				Signer:    kp.Address().AsIotaAddress(),
-				ObjectID:  anchor.ObjectID,
-				Recipient: result.committeeAddress.AsIotaAddress(),
-				GasBudget: iotajsonrpc.NewBigInt(iotaclient.DefaultGasBudget),
-			})
-			if err != nil {
-				return fmt.Errorf("failed to construct transfer anchor: %w", err)
-			}
-
-			_, err = cliclients.L1Client().SignAndExecuteTransaction(ctx, &iotaclient.SignAndExecuteTransactionRequest{
-				Signer:      cryptolib.SignerToIotaSigner(kp),
-				TxDataBytes: transferAnchor.TxBytes,
-				Options: &iotajsonrpc.IotaTransactionBlockResponseOptions{
-					ShowObjectChanges: true,
-				},
-			})
-			if err != nil {
-				return fmt.Errorf("failed to execute transfer anchor: %w", err)
-			}
-			config.AddChain(chainName, anchor.ObjectID.String())
-
-			fmt.Printf("\nChain has been deployed.\nID: %s\nStateMetadata: %v\n", anchor.ObjectID.String(), anchorStateMetadata)
-			fmt.Printf("Create the following path: './waspdb/chains/data/%s' and move or link the chain files into it.\n", anchor.ObjectID.String())
-			fmt.Println("Then call `chain activate` to finalize the deployment.")
-			return nil
+			return runImportChain(args[0], node, peers, quorum, chainName)
 		},
 	}
 

--- a/tools/wasp-cli/chain/info.go
+++ b/tools/wasp-cli/chain/info.go
@@ -30,7 +30,10 @@ func initInfoCmd() *cobra.Command { //nolint:funlen
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)

--- a/tools/wasp-cli/chain/metadata.go
+++ b/tools/wasp-cli/chain/metadata.go
@@ -94,7 +94,10 @@ func initMetadataCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chainAliasName = defaultChainFallback(chainAliasName)
+			chainAliasName, err = defaultChainFallback(chainAliasName)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 

--- a/tools/wasp-cli/chain/postrequest.go
+++ b/tools/wasp-cli/chain/postrequest.go
@@ -54,7 +54,10 @@ func initPostRequestCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chain = defaultChainFallback(chain)
+			chain, err = defaultChainFallback(chain)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 

--- a/tools/wasp-cli/chain/rebuild-index.go
+++ b/tools/wasp-cli/chain/rebuild-index.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	"fortio.org/safecast"
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	hivedb "github.com/iotaledger/hive.go/db"
@@ -22,17 +21,25 @@ func initBuildIndex() *cobra.Command {
 		Use:   "build-index <waspdb path> <indexdb destination path>",
 		Short: "Builds a new EVM JSONRPC index db",
 		Args:  cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := log.HiveLogger()
 
 			waspDBPath := args[0]
 			db, err := database.NewDatabase(hivedb.EngineRocksDB, waspDBPath, false, database.CacheSizeDefault)
-			log.Check(err)
+			if err != nil {
+				return err
+			}
 
-			waspDBStore := indexedstore.New(lo.Must(state.NewStoreReadonly(db.KVStore())))
+			storeRO, err := state.NewStoreReadonly(db.KVStore())
+			if err != nil {
+				return err
+			}
+			waspDBStore := indexedstore.New(storeRO)
 
 			latestIndex, err := waspDBStore.LatestBlockIndex()
-			log.Check(err)
+			if err != nil {
+				return err
+			}
 
 			logger.LogInfo("Creating index in parallel mode.")
 			logger.LogInfof("Latest block index: %d\n", latestIndex)
@@ -40,7 +47,9 @@ func initBuildIndex() *cobra.Command {
 			index := jsonrpc.NewIndex(waspDBStore.StateByTrieRoot, hivedb.EngineRocksDB, args[1])
 
 			block, err := waspDBStore.StateByIndex(latestIndex)
-			log.Check(err)
+			if err != nil {
+				return err
+			}
 
 			logger.LogInfof("Indexing with %d cores.\n", workers)
 
@@ -51,8 +60,10 @@ func initBuildIndex() *cobra.Command {
 				return waspDBStore
 			}
 
-			err = index.IndexAllBlocksInParallel(logger, storeProvider, block.TrieRoot(), workers)
-			log.Check(err)
+			if err := index.IndexAllBlocksInParallel(logger, storeProvider, block.TrieRoot(), workers); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/tools/wasp-cli/chain/register-erc20-native-token.go
+++ b/tools/wasp-cli/chain/register-erc20-native-token.go
@@ -33,7 +33,10 @@ func initRegisterERC20NativeTokenCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chainAliasName = defaultChainFallback(chainAliasName)
+			chainAliasName, err = defaultChainFallback(chainAliasName)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 

--- a/tools/wasp-cli/chain/rotate.go
+++ b/tools/wasp-cli/chain/rotate.go
@@ -5,6 +5,7 @@ package chain
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -78,8 +79,8 @@ func initChangeGovControllerCmd() *cobra.Command {
 		Use:   "change-gov-controller <address> --chain=<chainID>",
 		Short: "Changes the governance controller for a given chain (WARNING: you will lose control over the chain)",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			panic("refactor me: l1connection.OutputMap")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("change-gov-controller command is not implemented yet")
 			/*
 				chain := config.GetChain(defaultChainFallback(chain))
 

--- a/tools/wasp-cli/chain/set-coin-metadata.go
+++ b/tools/wasp-cli/chain/set-coin-metadata.go
@@ -32,7 +32,10 @@ func initSetCoinMetadataCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			chainAliasName = defaultChainFallback(chainAliasName)
+			chainAliasName, err = defaultChainFallback(chainAliasName)
+			if err != nil {
+				return err
+			}
 			ctx := context.Background()
 			client := cliclients.WaspClientWithVersionCheck(ctx, node)
 

--- a/tools/wasp-cli/codec/cmd.go
+++ b/tools/wasp-cli/codec/cmd.go
@@ -6,7 +6,6 @@ package codec
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/spf13/cobra"
@@ -68,14 +67,13 @@ func initDecodeCmd() *cobra.Command {
 		Use:   "call-result <type> [<type> ...]",
 		Short: "Decode the output of a contract function call",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, cmdArgs []string) {
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
 			callResults := util.ReadCallResultsAsJSON()
 
 			if len(callResults) != len(cmdArgs) {
 				log.Printf("Number of provided result types does not match number of results: types = %v, results = %v\n",
 					len(cmdArgs), len(callResults))
-				os.Exit(1)
-				return
+				return fmt.Errorf("mismatch between number of provided result types (%d) and results (%d)", len(cmdArgs), len(callResults))
 			}
 
 			for i := range cmdArgs {
@@ -83,6 +81,7 @@ func initDecodeCmd() *cobra.Command {
 				val := util.ValueToString(vtype, callResults[i])
 				log.Printf("[%v]: %s\n", i, val)
 			}
+			return nil
 		},
 	}
 }
@@ -92,11 +91,13 @@ func initDecodeWALCmd() *cobra.Command {
 		Use:   "wal <path>",
 		Short: "Parses and dumps a WAL file",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Reading WAL file '%s'\n", args[0])
 
 			block, err := utils.BlockFromFilePath(args[0])
-			log.Check(err)
+			if err != nil {
+				return fmt.Errorf("failed to read WAL file '%s': %w", args[0], err)
+			}
 
 			fmt.Printf("Block Number: %v\n", block.StateIndex())
 			fmt.Printf("L1 Commitment: %v\n", block.L1Commitment().String())
@@ -120,19 +121,19 @@ func initDecodeWALCmd() *cobra.Command {
 			fmt.Printf("\nRequests:\n\n")
 			receipts, err := blocklog.RequestReceiptsFromBlock(block)
 			if err != nil {
-				fmt.Println("Failed to decode receipts")
-				fmt.Println(err)
-			} else {
-				if len(receipts) == 0 {
-					fmt.Printf("No requests\n")
-				} else {
-					for i, receipt := range receipts {
-						fmt.Printf("%v:\n", i)
-						fmt.Printf("%v\n", receipt.String())
-					}
-					fmt.Printf("\n\n")
-				}
+				return fmt.Errorf("failed to decode receipts: %w", err)
 			}
+
+			if len(receipts) == 0 {
+				fmt.Printf("No requests\n")
+			} else {
+				for i, receipt := range receipts {
+					fmt.Printf("%v:\n", i)
+					fmt.Printf("%v\n", receipt.String())
+				}
+				fmt.Printf("\n\n")
+			}
+			return nil
 		},
 	}
 }

--- a/tools/wasp-cli/codec/cmd.go
+++ b/tools/wasp-cli/codec/cmd.go
@@ -143,12 +143,21 @@ func initDecodeMetadataCmd() *cobra.Command {
 		Use:   "metadata <0x...>",
 		Short: "Translates metadata from Hex to a humanly-readable format",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			metadata, err := isc.RequestMetadataFromBytes(hexutil.MustDecode(args[0]))
-			log.Check(err)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bytes, err := hexutil.Decode(args[0])
+			if err != nil {
+				return err
+			}
+			metadata, err := isc.RequestMetadataFromBytes(bytes)
+			if err != nil {
+				return err
+			}
 			jsonBytes, err := json.MarshalIndent(metadata, "", "  ")
-			log.Check(err)
+			if err != nil {
+				return err
+			}
 			log.Printf("%s\n", jsonBytes)
+			return nil
 		},
 	}
 }
@@ -158,10 +167,17 @@ func initDecodeGasFeePolicy() *cobra.Command {
 		Use:   "fee-policy <0x...>",
 		Short: "Translates gas fee policy from Hex to a humanly-readable format",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			bytes, err := cryptolib.DecodeHex(args[0])
-			log.Check(err)
-			log.Printf("%v", gas.MustFeePolicyFromBytes(bytes).String())
+			if err != nil {
+				return err
+			}
+			fp, err := gas.FeePolicyFromBytes(bytes)
+			if err != nil {
+				return err
+			}
+			log.Printf("%v", fp.String())
+			return nil
 		},
 	}
 }
@@ -177,18 +193,22 @@ func initEncodeGasFeePolicy() *cobra.Command {
 		Use:   "fee-policy",
 		Short: "Translates metadata from Hex to a humanly-readable format",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			feePolicy := gas.DefaultFeePolicy()
 
 			if gasPerToken != "" {
 				ratio, err := wasputil.Ratio32FromString(gasPerToken)
-				log.Check(err)
+				if err != nil {
+					return err
+				}
 				feePolicy.GasPerToken = ratio
 			}
 
 			if evmGasRatio != "" {
 				ratio, err := wasputil.Ratio32FromString(evmGasRatio)
-				log.Check(err)
+				if err != nil {
+					return err
+				}
 				feePolicy.EVMGasRatio = ratio
 			}
 
@@ -197,6 +217,7 @@ func initEncodeGasFeePolicy() *cobra.Command {
 			}
 
 			log.Printf("%s", cryptolib.EncodeHex(feePolicy.Bytes()))
+			return nil
 		},
 	}
 

--- a/tools/wasp-cli/disrec/cmd.go
+++ b/tools/wasp-cli/disrec/cmd.go
@@ -14,7 +14,6 @@ import (
 	hivep2p "github.com/iotaledger/hive.go/crypto/p2p"
 	hivelog "github.com/iotaledger/hive.go/log"
 
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	"github.com/iotaledger/wasp/v2/clients/iota-go/iotaclient"
@@ -51,92 +50,145 @@ func initSignAndPostCmd() *cobra.Command {
 			  - <committee_keys_dir>/<any>/dkshares/0x...hex....json\n
 			`,
 		Args: cobra.ExactArgs(4),
-		Run: func(cmd *cobra.Command, args []string) {
-			//
-			// Read the serialized TX Data.
-			txBytesFile := args[0]
-			txBytesRaw := lo.Must(os.ReadFile(txBytesFile))
-
-			// To make handling unsigned tx easier, a hex encoded value might make sense,
-			// in case we want to print the data instead of exporting a file directly.
-			txBytes := lo.Must(hexutil.Decode(string(txBytesRaw)))
-
-			//
-			// Parse the committee address.
-			committeeAddressStr := args[1]
-			committeeAddress := lo.Must(cryptolib.AddressFromHex(committeeAddressStr))
-			//
-			// Read the node keys and construct the DK Registries and the signer.
-			committeeKeysDir := args[2]
-			if !lo.Must(os.Stat(committeeKeysDir)).IsDir() {
-				panic("committee keys must be a directory")
-			}
-
-			var nodeIDs []gpa.NodeID
-			var peerIdentities []*cryptolib.KeyPair
-			var dkRegistries []registry.DKShareRegistryProvider
-
-			for _, entry := range lo.Must(os.ReadDir(committeeKeysDir)) {
-				if !entry.IsDir() {
-					continue
-				}
-				identityPath := filepath.Join(committeeKeysDir, entry.Name(), "identity", "identity.key")
-				if lo.Must(os.Stat(identityPath)).IsDir() {
-					continue
-				}
-
-				dkSharesDir := filepath.Join(committeeKeysDir, entry.Name(), "dkshares")
-				dkSharePath := filepath.Join(dkSharesDir, committeeAddressStr+".json")
-				if lo.Must(os.Stat(dkSharePath)).IsDir() {
-					continue
-				}
-
-				privKeyRaw, newlyCreated, err := hivep2p.LoadOrCreateIdentityPrivateKey(identityPath, "")
-				if err != nil || newlyCreated {
-					continue
-				}
-
-				privKey := lo.Must(cryptolib.PrivateKeyFromBytes(lo.Must(privKeyRaw.Raw())))
-				keyPair := cryptolib.KeyPairFromPrivateKey(privKey)
-				nodeID := gpa.NodeIDFromPublicKey(keyPair.GetPublicKey())
-
-				nodeIDs = append(nodeIDs, nodeID)
-				peerIdentities = append(peerIdentities, keyPair)
-				dkRegistries = append(dkRegistries, lo.Must(registry.NewDKSharesRegistry(dkSharesDir, privKey)))
-			}
-			log := hivelog.NewLogger(hivelog.WithName("disrec"))
-			signer := testpeers.NewTestDSSSigner(committeeAddress, dkRegistries, nodeIDs, peerIdentities, log)
-
-			//
-			// Sign and Post the TX to the L1.
-			iotaL1ClientURL := args[3]
-			ctx := context.Background()
-			httpClient := iscmoveclient.NewHTTPClient(iotaL1ClientURL, "", iotaclient.WaitForEffectsEnabled)
-			res, err := httpClient.SignAndExecuteTransaction(ctx, &iotaclient.SignAndExecuteTransactionRequest{
-				TxDataBytes: txBytes,
-				Signer:      cryptolib.SignerToIotaSigner(signer),
-				Options: &iotajsonrpc.IotaTransactionBlockResponseOptions{
-					ShowEffects:        true,
-					ShowObjectChanges:  true,
-					ShowBalanceChanges: true,
-					ShowEvents:         true,
-				},
-			})
-			if err != nil {
-				panic(fmt.Errorf("error executing tx: %s Res: %v", err, res))
-			}
-			if !res.Effects.Data.IsSuccess() {
-				panic(fmt.Errorf("error executing tx: %s Digest: %s", res.Effects.Data.V1.Status.Error, res.Digest))
-			}
-
-			log.LogInfof("Transaction posted! Digest: %s\n", res.Digest)
-			log.LogInfo("Transaction data:")
-
-			log.LogInfof("Object Changes:\n%v\n", string(lo.Must(json.MarshalIndent(res.ObjectChanges, "\t", " "))))
-			log.LogInfof("Effects:\n%v\n", string(lo.Must(json.MarshalIndent(res.Effects, "\t", " "))))
-		},
+		RunE: runSignAndPost,
 	}
 	return cmd
+}
+
+// runSignAndPost executes the sign_post command logic.
+func runSignAndPost(cmd *cobra.Command, args []string) error {
+	// Read and decode the serialized TX Data.
+	txBytes, err := readAndDecodeTxBytes(args[0])
+	if err != nil {
+		return err
+	}
+
+	// Parse the committee address.
+	committeeAddressStr := args[1]
+	committeeAddress, err := cryptolib.AddressFromHex(committeeAddressStr)
+	if err != nil {
+		return fmt.Errorf("invalid committee address '%s': %w", committeeAddressStr, err)
+	}
+
+	// Build signer from committee keys.
+	nodeIDs, peerIdentities, dkRegistries, err := collectDKComponents(args[2], committeeAddressStr)
+	if err != nil {
+		return err
+	}
+	log := hivelog.NewLogger(hivelog.WithName("disrec"))
+	signer := testpeers.NewTestDSSSigner(committeeAddress, dkRegistries, nodeIDs, peerIdentities, log)
+
+	// Sign and Post the TX to the L1.
+	iotaL1ClientURL := args[3]
+	ctx := context.Background()
+	httpClient := iscmoveclient.NewHTTPClient(iotaL1ClientURL, "", iotaclient.WaitForEffectsEnabled)
+	res, execErr := httpClient.SignAndExecuteTransaction(ctx, &iotaclient.SignAndExecuteTransactionRequest{
+		TxDataBytes: txBytes,
+		Signer:      cryptolib.SignerToIotaSigner(signer),
+		Options: &iotajsonrpc.IotaTransactionBlockResponseOptions{
+			ShowEffects:        true,
+			ShowObjectChanges:  true,
+			ShowBalanceChanges: true,
+			ShowEvents:         true,
+		},
+	})
+	if execErr != nil {
+		return fmt.Errorf("error executing tx: %w, res: %v", execErr, res)
+	}
+	if !res.Effects.Data.IsSuccess() {
+		return fmt.Errorf("error executing tx: %s, digest: %s", res.Effects.Data.V1.Status.Error, res.Digest)
+	}
+
+	log.LogInfof("Transaction posted! Digest: %s\n", res.Digest)
+	log.LogInfo("Transaction data:")
+
+	if objChanges, err := json.MarshalIndent(res.ObjectChanges, "\t", " "); err == nil {
+		log.LogInfof("Object Changes:\n%v\n", string(objChanges))
+	}
+	if effects, err := json.MarshalIndent(res.Effects, "\t", " "); err == nil {
+		log.LogInfof("Effects:\n%v\n", string(effects))
+	}
+	return nil
+}
+
+// readAndDecodeTxBytes reads the file and hex-decodes its contents.
+func readAndDecodeTxBytes(txBytesFile string) ([]byte, error) {
+	txBytesRaw, err := os.ReadFile(txBytesFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read tx bytes file '%s': %w", txBytesFile, err)
+	}
+	// To make handling unsigned tx easier, a hex encoded value might make sense,
+	// in case we want to print the data instead of exporting a file directly.
+	txBytes, err := hexutil.Decode(string(txBytesRaw))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode tx bytes: %w", err)
+	}
+	return txBytes, nil
+}
+
+// collectDKComponents scans the committee keys directory and builds the DK registries and identities.
+func collectDKComponents(committeeKeysDir, committeeAddressStr string) ([]gpa.NodeID, []*cryptolib.KeyPair, []registry.DKShareRegistryProvider, error) {
+	stat, err := os.Stat(committeeKeysDir)
+	if err != nil || !stat.IsDir() {
+		return nil, nil, nil, fmt.Errorf("committee keys must be a directory: %s", committeeKeysDir)
+	}
+	entries, err := os.ReadDir(committeeKeysDir)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to read committee keys directory '%s': %w", committeeKeysDir, err)
+	}
+	var nodeIDs []gpa.NodeID
+	var peerIdentities []*cryptolib.KeyPair
+	var dkRegistries []registry.DKShareRegistryProvider
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		nodeID, keyPair, reg, ok := loadNodeComponents(filepath.Join(committeeKeysDir, entry.Name()), committeeAddressStr)
+		if !ok {
+			continue
+		}
+		nodeIDs = append(nodeIDs, nodeID)
+		peerIdentities = append(peerIdentities, keyPair)
+		if reg != nil {
+			dkRegistries = append(dkRegistries, reg)
+		}
+	}
+	return nodeIDs, peerIdentities, dkRegistries, nil
+}
+
+// loadNodeComponents tries to load identity and dkshare registry from a node subdirectory.
+// It returns ok=false if the directory doesn't contain the expected files or keys couldn't be loaded.
+func loadNodeComponents(nodeDir, committeeAddressStr string) (gpa.NodeID, *cryptolib.KeyPair, registry.DKShareRegistryProvider, bool) {
+	identityPath := filepath.Join(nodeDir, "identity", "identity.key")
+	if st, err := os.Stat(identityPath); err != nil || st.IsDir() {
+		return gpa.NodeID{}, nil, nil, false
+	}
+	// dkshare for this committee
+	dkSharesDir := filepath.Join(nodeDir, "dkshares")
+	dkSharePath := filepath.Join(dkSharesDir, committeeAddressStr+".json")
+	if st, err := os.Stat(dkSharePath); err != nil || st.IsDir() {
+		return gpa.NodeID{}, nil, nil, false
+	}
+	// load identity private key
+	privKeyRaw, newlyCreated, err := hivep2p.LoadOrCreateIdentityPrivateKey(identityPath, "")
+	if err != nil || newlyCreated {
+		return gpa.NodeID{}, nil, nil, false
+	}
+	privKeyBytes, err := privKeyRaw.Raw()
+	if err != nil {
+		return gpa.NodeID{}, nil, nil, false
+	}
+	privKey, err := cryptolib.PrivateKeyFromBytes(privKeyBytes)
+	if err != nil {
+		return gpa.NodeID{}, nil, nil, false
+	}
+	keyPair := cryptolib.KeyPairFromPrivateKey(privKey)
+	nodeID := gpa.NodeIDFromPublicKey(keyPair.GetPublicKey())
+	reg, err := registry.NewDKSharesRegistry(dkSharesDir, privKey)
+	if err != nil {
+		reg = nil
+	}
+	return nodeID, keyPair, reg, true
 }
 
 func Init(rootCmd *cobra.Command) {

--- a/tools/wasp-cli/format/glazed_formatter.go
+++ b/tools/wasp-cli/format/glazed_formatter.go
@@ -374,19 +374,17 @@ func FormatWalletAddress(addressIndex uint32, address string) error {
 	return defaultFormatter.FormatWalletAddress(addressIndex, address)
 }
 
-// FormatAndExitWithError formats an error and exits
+// FormatAndExitWithError formats an error for glazed without exiting
 func FormatAndExitWithError(cmd interface{}, err error) error {
 	if err == nil {
 		return nil
 	}
 
-	// Format the error
+	// Try to format the error using glazed
 	if formatErr := FormatError("application", err.Error()); formatErr != nil {
 		// If formatting fails, just print the error
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 	}
 
-	// Exit with error code
-	os.Exit(1)
-	return nil // Never reached
+	return err
 }

--- a/tools/wasp-cli/main.go
+++ b/tools/wasp-cli/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
@@ -37,7 +39,7 @@ func initRootCmd(waspVersion string) *cobra.Command {
 	NOTE: this is alpha software, only suitable for testing purposes.`,
 		SilenceUsage:  true, // Disable automatic help display on errors
 		SilenceErrors: true, // Disable automatic error display on errors
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			config.Read()
 			whitelistedCommands := map[string]struct{}{
 				"init":            {},
@@ -54,8 +56,9 @@ func initRootCmd(waspVersion string) *cobra.Command {
 				log.Printf("Please run `wasp-cli wallet-migrate keychain` to move your seed into the Keychain of your operating system,\n")
 				log.Printf("or switch to alternative wallet providers such as the Ledger with: `wasp-cli wallet-provider sdk_ledger`.\n")
 
-				log.Fatalf("The cli will now exit.")
+				return fmt.Errorf("the cli will now exit")
 			}
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -97,10 +100,11 @@ func init() {
 func main() {
 	err := rootCmd.Execute()
 	if err != nil {
-		// Format and display the error using glazed, then exit
+		// Format and display the error using glazed
 		if formatErr := format.FormatAndExitWithError(rootCmd, err); formatErr != nil {
-			// If glazed formatting fails, fall back to the original log.Check behavior
+			// If glazed formatting fails, fall back to the original log.Check behavior (which exits)
 			log.Check(err)
 		}
+		os.Exit(1)
 	}
 }

--- a/tools/wasp-cli/wallet/info.go
+++ b/tools/wasp-cli/wallet/info.go
@@ -18,13 +18,10 @@ func initAddressCmd() *cobra.Command {
 		Use:   "address",
 		Short: "Show the wallet address",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			myWallet := wallet.Load()
 			address := myWallet.Address()
-			err := format.FormatWalletAddress(myWallet.AddressIndex(), address.String())
-			if err != nil {
-				log.Printf("Error formatting output: %v", err)
-			}
+			return format.FormatWalletAddress(myWallet.AddressIndex(), address.String())
 		},
 	}
 }
@@ -34,22 +31,16 @@ func initBalanceCmd() *cobra.Command {
 		Use:   "balance",
 		Short: "Show the wallet balance",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			myWallet := wallet.Load()
 			address := myWallet.Address()
 			balance, err := cliclients.L1Client().GetAllBalances(context.Background(), address.AsIotaAddress())
 			if err != nil {
-				formatErr := format.FormatError("wallet_balance", fmt.Sprintf("Address: %s (index %d), Error: %s", address.String(), myWallet.AddressIndex(), err.Error()))
-				if formatErr != nil {
-					log.Printf("Error formatting output: %v", formatErr)
-				}
-				return
+				// Return the error so it can be formatted by the top-level handler
+				return fmt.Errorf("fetching balance for address %s (index %d): %w", address.String(), myWallet.AddressIndex(), err)
 			}
 
-			err = format.FormatWalletBalance(myWallet.AddressIndex(), address.String(), balance)
-			if err != nil {
-				log.Printf("Error formatting output: %v", err)
-			}
+			return format.FormatWalletBalance(myWallet.AddressIndex(), address.String(), balance)
 		},
 	}
 }

--- a/tools/wasp-cli/wallet/request-funds.go
+++ b/tools/wasp-cli/wallet/request-funds.go
@@ -1,8 +1,6 @@
 package wallet
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	"github.com/iotaledger/wasp/v2/tools/wasp-cli/util"
@@ -17,18 +15,21 @@ func initRequestFundsCmd() *cobra.Command {
 		Use:   "request-funds",
 		Short: "Request funds from the faucet",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			address := wallet.Load().Address()
-			log.Check(cliclients.L1Client().RequestFunds(context.Background(), *address))
+			if err := cliclients.L1Client().RequestFunds(cmd.Context(), *address); err != nil {
+				return err
+			}
 
 			model := &RequestFundsModel{
 				Address: address.String(),
 				Message: "success",
 			}
 
-			util.TryManageCoinsAmount(context.Background())
+			util.TryManageCoinsAmount(cmd.Context())
 
 			log.PrintCLIOutput(model)
+			return nil
 		},
 	}
 }

--- a/tools/wasp-cli/wallet/wallet.go
+++ b/tools/wasp-cli/wallet/wallet.go
@@ -21,11 +21,14 @@ func initInitCmd() *cobra.Command {
 		Use:   "init",
 		Short: "Initialize a new wallet",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			wallet.InitWallet(initOverwrite)
 
 			config.SetWalletProviderString(string(wallet.GetWalletProvider()))
-			log.Check(config.WriteConfig())
+			if err := config.WriteConfig(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&initOverwrite, "overwrite", false, "allow overwriting existing seed")

--- a/tools/wasp-cli/wallet/wallet_provider.go
+++ b/tools/wasp-cli/wallet/wallet_provider.go
@@ -12,14 +12,19 @@ func initWalletProviderCmd() *cobra.Command {
 		Use:   "provider (keychain, ledger)",
 		Short: "Get or set wallet provider (keychain, ledger)",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				log.Printf("Wallet provider: %s\n", string(wallet.GetWalletProvider()))
-				return
+				return nil
 			}
 
-			log.Check(wallet.SetWalletProvider(wallet.WalletProvider(args[0])))
-			log.Check(config.WriteConfig())
+			if err := wallet.SetWalletProvider(wallet.WalletProvider(args[0])); err != nil {
+				return err
+			}
+			if err := config.WriteConfig(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 }

--- a/tools/wasp-cli/waspcmd/cmd.go
+++ b/tools/wasp-cli/waspcmd/cmd.go
@@ -88,5 +88,5 @@ func DefaultWaspNodeFallback(node string) (string, error) {
 	default:
 		return "", errors.New("more than 1 wasp node in the configuration, you can specify the target node with `--node=<name>`")
 	}
-	panic("unreachable")
+	return "", errors.New("unreachable")
 }


### PR DESCRIPTION
This PR converts most of the cobra commands to return errors. There are still a few left but this PR was already long enough and it covers the big ones. 
Also fixed couple of linter gripes for cyclomatic complexity and function length which required reorganizing some unrelated functions
