### PR TITLE
test: update gas and fee assertions in EVM tests

### DIFF
--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -984,8 +984,8 @@ func TestEVMGasPriceMismatch(t *testing.T) {
 			evmGasRatio:   util.Ratio32{A: 1, B: 1},   // default
 			txGasPrice:    nil,
 			expectedError: "insufficient gas price: got 0, minimum is 10000000",
-			gasBurned:     168107,
-			feeCharged:    1682,
+			gasBurned:     223107,
+			feeCharged:    2232,
 		},
 		{
 			name:          "default policy, gas price too low",
@@ -993,8 +993,8 @@ func TestEVMGasPriceMismatch(t *testing.T) {
 			evmGasRatio:   util.Ratio32{A: 1, B: 1},   // default
 			txGasPrice:    big.NewInt(9999999),
 			expectedError: "insufficient gas price: got 9999999, minimum is 10000000",
-			gasBurned:     168107,
-			feeCharged:    1682,
+			gasBurned:     223107,
+			feeCharged:    2232,
 		},
 		{
 			name:        "default policy, gas price just enough",
@@ -1026,8 +1026,8 @@ func TestEVMGasPriceMismatch(t *testing.T) {
 			evmGasRatio:   util.Ratio32{A: 1, B: 1},  // default
 			txGasPrice:    big.NewInt(19999999),
 			expectedError: "insufficient gas price: got 19999999, minimum is 20000000",
-			gasBurned:     168107,
-			feeCharged:    2*1682 - 1,
+			gasBurned:     223107,
+			feeCharged:    2*2232 - 1,
 		},
 		{
 			name:        "gas more expensive, gas price just enough",


### PR DESCRIPTION
This PR updates gas usage expectations in tests due to `storage.sol` having a new method added.