### PR TITLE
test: improve access node tests by replacing fixed sleeps with polling

### DIFF
--- a/tools/cluster/tests/access_nodes_test.go
+++ b/tools/cluster/tests/access_nodes_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -79,8 +80,10 @@ func (e *ChainEnv) testPermissionlessAccessNode(t *testing.T) {
 	_, err = nodeClient.ChainsAPI.AddAccessNode(context.Background(), accessNodePeerInfo.PublicKey).Execute()
 	require.NoError(t, err)
 
-	// give some time for the access node to sync
-	time.Sleep(2 * time.Second)
+	// wait for the access node to report the chain as active (avoid fixed sleeps)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, waitForAccessNodeChainActive(reqCtx, accessNodeClient))
 
 	// send a request to the access node
 	myClient := chainclient.New(
@@ -104,17 +107,124 @@ func (e *ChainEnv) testPermissionlessAccessNode(t *testing.T) {
 	_, err = nodeClient.ChainsAPI.RemoveAccessNode(context.Background(), accessNodePeerInfo.PublicKey).Execute()
 	require.NoError(t, err)
 
-	time.Sleep(1 * time.Second) // Access/Server node info is exchanged asynchronously.
-
-	// try sending the request again
-	req, err = myClient.PostOffLedgerRequest(context.Background(), inccounter.FuncIncCounter.Message(nil))
+	// proactively deactivate the chain on the former access node to speed up detachment and reduce flakiness
+	_, err = accessNodeClient.ChainsAPI.
+		SetChainRecord(context.Background(), e.Chain.ChainID.String()).
+		ChainRecord(apiclient.ChainRecord{
+			IsActive:    false,
+			AccessNodes: []string{},
+		}).Execute()
 	require.NoError(t, err)
 
-	// request is not processed after a while
-	time.Sleep(2 * time.Second)
-	receipt, _, err := nodeClient.ChainsAPI.GetReceipt(context.Background(), req.ID().String()).Execute()
+	// wait until the access node is fully detached: not listed by the committee and not active itself
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel2()
+	require.NoError(t, waitUntilAccessNodeDetached(ctx2, nodeClient, accessNodeClient, accessNodePeerInfo.PublicKey))
 
+	// try sending the request again (the access node is detached, so this may return a 4xx/5xx). We only need the request ID
+	req, err = myClient.PostOffLedgerRequest(context.Background(), inccounter.FuncIncCounter.Message(nil))
+	if err != nil {
+		// It's expected to fail (e.g., 404/500) since the access node is no longer serving the chain
+		t.Logf("posting to detached access node returned error (expected): %v", err)
+	}
+	// If the client couldn't even construct/sign the request (e.g., failed to fetch nonce via detached node),
+	// build a signed off-ledger request locally to obtain a stable request ID for negative verification.
+	if req == nil {
+		// Prefer a fresh nonce from the committee node; fall back to a synthetic one if unavailable.
+		nonce := uint64(time.Now().UnixNano())
+		if nonceFromCommittee, err2 := chainclient.New(e.Clu.L1Client(), nodeClient, e.Chain.ChainID, keyPair).ISCNonce(context.Background()); err2 == nil {
+			nonce = nonceFromCommittee
+		} else {
+			t.Logf("could not fetch ISC nonce from committee, using synthetic nonce: %v", err2)
+		}
+		tmp := isc.NewOffLedgerRequest(e.Chain.ChainID, inccounter.FuncIncCounter.Message(nil), nonce, iotaclient.DefaultGasBudget)
+		tmp.WithNonce(nonce)
+		req = tmp.Sign(keyPair)
+	}
+
+	// request is not processed after a short while; poll for 404 on the committee node
+	deadline := time.Now().Add(30 * time.Second)
+	var receipt *apiclient.ReceiptResponse
+	for time.Now().Before(deadline) {
+		receipt, _, err = nodeClient.ChainsAPI.GetReceipt(context.Background(), req.ID().String()).Execute()
+		if err != nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 	require.Error(t, err)
 	require.Regexp(t, `404`, err.Error())
 	require.Nil(t, receipt)
+}
+
+// waitForAccessNodeChainActive polls the access node until it reports the chain as active via /v1/chain
+func waitForAccessNodeChainActive(ctx context.Context, accessNodeClient *apiclient.APIClient) error {
+	for {
+		info, _, err := accessNodeClient.ChainsAPI.GetChainInfo(ctx).Execute()
+		if err == nil && info != nil && info.IsActive {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			if err == nil {
+				return context.DeadlineExceeded
+			}
+			return err
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// waitUntilAccessNodeDetached waits until BOTH conditions are met:
+// 1) The main node's committee info no longer lists the access node public key among access nodes
+// 2) The access node's /v1/chain reports inactive or returns a non-2xx error (meaning the chain is not active/available there)
+// It uses an exponential backoff and respects the provided context deadline.
+func waitUntilAccessNodeDetached(ctx context.Context, mainNodeClient, accessNodeClient *apiclient.APIClient, accessNodePubKey string) error {
+	backoff := 200 * time.Millisecond
+	const maxBackoff = 2 * time.Second
+
+	for {
+		// Condition 1: not listed by committee
+		cond1 := false
+		if ci, _, err := mainNodeClient.ChainsAPI.GetCommitteeInfo(ctx).Execute(); err == nil && ci != nil {
+			found := false
+			for _, n := range ci.AccessNodes {
+				if n.Node.PublicKey == accessNodePubKey {
+					found = true
+					break
+				}
+			}
+			cond1 = !found
+		}
+
+		// Condition 2: access node reports chain inactive or endpoint is unavailable
+		cond2 := false
+		if info, resp, err := accessNodeClient.ChainsAPI.GetChainInfo(ctx).Execute(); err != nil {
+			// any transport/openapi error is considered detached/unavailable
+			cond2 = true
+		} else {
+			// if we managed to call it, consider detached only when not active
+			cond2 = info == nil || !info.IsActive
+			// just in case, treat 4xx/5xx as detached too (should surface as error in client, but be defensive)
+			if resp != nil && resp.StatusCode >= 400 {
+				cond2 = true
+			}
+		}
+
+		if cond1 && cond2 {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("access node not fully detached before timeout: committee_unlisted=%v, accessnode_inactive=%v", cond1, cond2)
+		case <-time.After(backoff):
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Remove some hardcoded timeouts in cluster tests and poll for updates instead. 