### PR TITLE
Fix test timeouts and races

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,7 +51,7 @@ jobs:
       # Here used to be a make build step, but we separated it into another job
 
       - name: Test
-        run: make test-short
+        run: make test-medium
 
   golangci:
     name: Lint

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,11 @@ test: install
 test-short:
 	go test -race -ldflags $(BUILD_LD_FLAGS) --short --count 1 -timeout 25m -failfast $(shell go list ./...)
 
+test-medium:
+	go test -race -ldflags $(BUILD_LD_FLAGS) --short --count 1 -timeout 60m -failfast $(shell go list ./...)
+
 test-cluster: install
-	go test -race -ldflags $(BUILD_LD_FLAGS) --count 1 -timeout 25m -failfast $(shell go list ./tools/cluster/tests/...)
+	go test -race -ldflags $(BUILD_LD_FLAGS) --count 1 -timeout 60m -failfast $(shell go list ./tools/cluster/tests/...)
 
 install-cli:
 	cd tools/wasp-cli && go mod tidy && go install -ldflags $(BUILD_LD_FLAGS)

--- a/clients/iota-go/iotatest/faucet.go
+++ b/clients/iota-go/iotatest/faucet.go
@@ -13,9 +13,6 @@ import (
 )
 
 func MakeSignerWithFunds(index int, faucetURL string, reader ...iotaclient.CoinReader) iotasigner.Signer {
-	if index == 0 {
-		index = rand.Intn(256)
-	}
 	return MakeSignerWithFundsFromSeed(testkey.NewTestSeedBytes(), index, faucetURL, reader...)
 }
 

--- a/clients/iota-go/iotatest/faucet.go
+++ b/clients/iota-go/iotatest/faucet.go
@@ -2,6 +2,9 @@ package iotatest
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/iotaledger/wasp/v2/clients/iota-go/iotaclient"
@@ -10,6 +13,9 @@ import (
 )
 
 func MakeSignerWithFunds(index int, faucetURL string, reader ...iotaclient.CoinReader) iotasigner.Signer {
+	if index == 0 {
+		index = rand.Intn(256)
+	}
 	return MakeSignerWithFundsFromSeed(testkey.NewTestSeedBytes(), index, faucetURL, reader...)
 }
 
@@ -23,8 +29,21 @@ func MakeSignerWithFundsFromSeed(
 
 	// there are only 256 different signers can be generated
 	signer := iotasigner.NewSignerByIndex(seed, keySchemeFlag, index)
-	err := iotaclient.RequestFundsFromFaucet(context.Background(), signer.Address(), faucetURL)
-	if err != nil {
+	var err error
+	for i := 0; i < 15; i++ {
+		err = iotaclient.RequestFundsFromFaucet(context.Background(), signer.Address(), faucetURL)
+		if err == nil {
+			break
+		}
+		if i < 14 && (strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "Too Many Requests")) {
+			delay := time.Duration(float64(time.Second) * (10 * float64(i+1)))
+			jitter := time.Duration(rand.Float64() * float64(5*time.Second))
+			finalDelay := delay + jitter
+
+			fmt.Printf("faucet rate limited (attempt %d/15), sleeping %v before retrying\n", i+1, finalDelay)
+			time.Sleep(finalDelay)
+			continue
+		}
 		panic(err)
 	}
 	if len(reader) > 0 {

--- a/clients/iotagraphql/iotaclienttest/api_read_test.go
+++ b/clients/iotagraphql/iotaclienttest/api_read_test.go
@@ -66,7 +66,7 @@ func TestGetTransactionBlock(t *testing.T) {
 
 func TestQueryTransactionBlocks(t *testing.T) {
 	ctx := context.Background()
-	client := clients.NewGraphQLClient(iotaconn.TestnetGraphQLEndpointURL)
+	client := clients.NewGraphQLClientWithTimeout(iotaconn.TestnetGraphQLEndpointURL, 60*time.Second)
 
 	resp, err := client.QueryTransactionBlocks(ctx, iotaclient.QueryTransactionBlocksRequest{
 		Limit: lo.ToPtr(int(3)),

--- a/clients/iotagraphql/iotaclienttest/api_read_test.go
+++ b/clients/iotagraphql/iotaclienttest/api_read_test.go
@@ -23,12 +23,15 @@ func TestGetObject(t *testing.T) {
 	owner := iotago.MustAddressFromHex(testcommon.TestAddress)
 
 	limit := int(1)
-	coinsResp, err := client.GetCoins(ctx, iotaclient.GetCoinsRequest{
-		Owner: owner,
-		Limit: limit,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, coinsResp.Data)
+	var coinsResp *iotajsonrpc.CoinPage
+	var err error
+	require.Eventually(t, func() bool {
+		coinsResp, err = client.GetCoins(ctx, iotaclient.GetCoinsRequest{
+			Owner: owner,
+			Limit: limit,
+		})
+		return err == nil && len(coinsResp.Data) > 0
+	}, 120*time.Second, 5*time.Second)
 
 	coin := coinsResp.Data[0]
 	objResp, err := client.GetObject(ctx, iotaclient.GetObjectRequest{
@@ -48,12 +51,15 @@ func TestGetTransactionBlock(t *testing.T) {
 	owner := iotago.MustAddressFromHex(testcommon.TestAddress)
 
 	limit := int(1)
-	coinsResp, err := client.GetCoins(ctx, iotaclient.GetCoinsRequest{
-		Owner: owner,
-		Limit: limit,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, coinsResp.Data)
+	var coinsResp *iotajsonrpc.CoinPage
+	var err error
+	require.Eventually(t, func() bool {
+		coinsResp, err = client.GetCoins(ctx, iotaclient.GetCoinsRequest{
+			Owner: owner,
+			Limit: limit,
+		})
+		return err == nil && len(coinsResp.Data) > 0
+	}, 120*time.Second, 5*time.Second)
 
 	digest := &coinsResp.Data[0].PreviousTransaction
 	resp, err := client.GetTransactionBlock(ctx, iotaclient.GetTransactionBlockRequest{
@@ -68,11 +74,14 @@ func TestQueryTransactionBlocks(t *testing.T) {
 	ctx := context.Background()
 	client := clients.NewGraphQLClientWithTimeout(iotaconn.TestnetGraphQLEndpointURL, 60*time.Second)
 
-	resp, err := client.QueryTransactionBlocks(ctx, iotaclient.QueryTransactionBlocksRequest{
-		Limit: lo.ToPtr(int(3)),
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, resp.Data)
+	var resp *iotajsonrpc.TransactionBlocksPage
+	var err error
+	require.Eventually(t, func() bool {
+		resp, err = client.QueryTransactionBlocks(ctx, iotaclient.QueryTransactionBlocksRequest{
+			Limit: lo.ToPtr(int(3)),
+		})
+		return err == nil && len(resp.Data) > 0
+	}, 3*time.Minute, 5*time.Second)
 }
 
 func TestTryGetPastObject(t *testing.T) {
@@ -82,12 +91,15 @@ func TestTryGetPastObject(t *testing.T) {
 	owner := iotago.MustAddressFromHex(testcommon.TestAddress)
 
 	limit := int(1)
-	coinsResp, err := client.GetCoins(ctx, iotaclient.GetCoinsRequest{
-		Owner: owner,
-		Limit: limit,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, coinsResp.Data)
+	var coinsResp *iotajsonrpc.CoinPage
+	var err error
+	require.Eventually(t, func() bool {
+		coinsResp, err = client.GetCoins(ctx, iotaclient.GetCoinsRequest{
+			Owner: owner,
+			Limit: limit,
+		})
+		return err == nil && len(coinsResp.Data) > 0
+	}, 120*time.Second, 5*time.Second)
 
 	coin := coinsResp.Data[0]
 	version := coin.Version.Uint64()

--- a/clients/iotagraphql/iotaclienttest/api_write_test.go
+++ b/clients/iotagraphql/iotaclienttest/api_write_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -92,9 +93,12 @@ func TestDryRunTransaction(t *testing.T) {
 func TestExecuteTransactionBlock(t *testing.T) {
 	client := clients.NewGraphQLClient(iotaconn.TestnetGraphQLEndpointURL)
 	signer := iotatest.MakeSignerWithFunds(0, iotaconn.TestnetFaucetURL, client)
-	coins, err := client.GetCoins(context.Background(), iotaclient.GetCoinsRequest{Owner: signer.Address(), Limit: 10})
-	require.NoError(t, err)
-	require.NotEmpty(t, coins.Data, "no coins indexed for %v after faucet", signer.Address().String())
+	var coins *iotajsonrpc.CoinPage
+	var err error
+	require.Eventually(t, func() bool {
+		coins, err = client.GetCoins(context.Background(), iotaclient.GetCoinsRequest{Owner: signer.Address(), Limit: 10})
+		return err == nil && len(coins.Data) > 0
+	}, 300*time.Second, 5*time.Second, "no coins indexed for %v after faucet", signer.Address().String())
 	pickedCoins, err := iotajsonrpc.PickupCoins(coins, big.NewInt(100), iotaclient.DefaultGasBudget, 0, 0)
 	require.NoError(t, err)
 	tx, err := client.PayAllIota(
@@ -123,9 +127,12 @@ func TestExecuteTransactionBlock(t *testing.T) {
 func TestSignAndExecuteTransaction(t *testing.T) {
 	client := clients.NewGraphQLClient(iotaconn.TestnetGraphQLEndpointURL)
 	signer := iotatest.MakeSignerWithFunds(0, iotaconn.TestnetFaucetURL, client)
-	coins, err := client.GetCoins(context.Background(), iotaclient.GetCoinsRequest{Owner: signer.Address(), Limit: 10})
-	require.NoError(t, err)
-	require.NotEmpty(t, coins.Data, "no coins indexed for %v after faucet", signer.Address().String())
+	var coins *iotajsonrpc.CoinPage
+	var err error
+	require.Eventually(t, func() bool {
+		coins, err = client.GetCoins(context.Background(), iotaclient.GetCoinsRequest{Owner: signer.Address(), Limit: 10})
+		return err == nil && len(coins.Data) > 0
+	}, 300*time.Second, 5*time.Second, "no coins indexed for %v after faucet", signer.Address().String())
 	pickedCoins, err := iotajsonrpc.PickupCoins(coins, big.NewInt(100), iotaclient.DefaultGasBudget, 0, 0)
 	require.NoError(t, err)
 	tx, err := client.PayAllIota(

--- a/components/webapi/webapi_test.go
+++ b/components/webapi/webapi_test.go
@@ -2,8 +2,10 @@ package webapi_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -46,19 +48,22 @@ func TestInternalServerErrors(t *testing.T) {
 		log.NewLogger(log.WithHandler(logger)),
 	)
 
-	time.Sleep(5 * time.Second)
-
 	// Add an endpoint that just panics with "foobar" and start the server
 	exceptionText := "foobar"
 	e.GET("/test", func(c echo.Context) error { panic(exceptionText) })
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	e.Listener = l
+
 	go func() {
-		err := e.Start(":9999")
-		require.ErrorIs(t, http.ErrServerClosed, err)
+		err := e.Start("")
+		require.ErrorIs(t, err, http.ErrServerClosed)
 	}()
 	defer e.Shutdown(context.Background())
 
 	// query the endpoint
-	req, err := http.NewRequest(http.MethodGet, "http://localhost:9999/test", http.NoBody)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/test", e.Listener.Addr().String()), http.NoBody)
 	require.NoError(t, err)
 
 	res, err := http.DefaultClient.Do(req)
@@ -69,7 +74,7 @@ func TestInternalServerErrors(t *testing.T) {
 	res.Body.Close()
 
 	// assert the exception is not present in the response (prevent leaking errors)
-	require.Equal(t, res.StatusCode, http.StatusInternalServerError)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	require.NotContains(t, string(resBody), exceptionText)
 
 	// assert the exception is logged

--- a/components/webapi/webapi_test.go
+++ b/components/webapi/webapi_test.go
@@ -57,8 +57,8 @@ func TestInternalServerErrors(t *testing.T) {
 	e.Listener = l
 
 	go func() {
-		err := e.Start("")
-		require.ErrorIs(t, err, http.ErrServerClosed)
+		err2 := e.Start("")
+		require.ErrorIs(t, err2, http.ErrServerClosed)
 	}()
 	defer e.Shutdown(context.Background())
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -12,6 +12,7 @@ dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0 h1:SPOUaucgtVl
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412 h1:GvWw74lx5noHocd+f6HBMXK6DuggBB1dhVkuGZbv7qM=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c h1:ivON6cwHK1OH26MZyWDCnbTRZZf0IhNsENoNAKFS1g4=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:OR8VhtwhcAI3U48/rzBsVOuHi0zDPzYI1xASVcdSgR8=
+github.com/99designs/gqlgen v0.17.57 h1:Ak4p60BRq6QibxY0lEc0JnQhDurfhxA67sp02lMjmPc=
 github.com/99designs/gqlgen v0.17.57/go.mod h1:Jx61hzOSTcR4VJy/HFIgXiQ5rJ0Ypw8DxWLjbYDAUw0=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0 h1:8q4SaHjFsClSvuVne0ID/5Ka8u3fcIHyqkLjcFpNRHQ=
@@ -43,6 +44,7 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aerospike/aerospike-client-go v1.35.2/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/chroma/v2 v2.14.0 h1:R3+wzpnUArGcQz7fCETQBzO5n9IMNi13iIs46aU4V9E=
 github.com/alecthomas/chroma/v2 v2.14.0/go.mod h1:QolEbTfmUHIMVpBqxeDnNBj2uoeI4EbYP4i6n68SG4I=
@@ -50,7 +52,9 @@ github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjH
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/alexflint/go-arg v1.5.1 h1:nBuWUCpuRy0snAG+uIJ6N0UvYxpxA0/ghA/AaHxlT8Y=
 github.com/alexflint/go-arg v1.5.1/go.mod h1:A7vTJzvjoaSTypg4biM5uYNTkJ27SkNTArtYXnlqVO8=
+github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
 github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/apache/thrift v0.0.0-20171203172758-327ebb6c2b6d/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -103,6 +107,7 @@ github.com/bmatcuk/doublestar/v4 v4.9.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTS
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625 h1:ckJgFhFWywOx+YLEMIJsTb+NV6NexWICk5+AMSuz3ss=
+github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/btcsuite/btcd v0.24.2 h1:aLmxPguqxza+4ag8R1I2nnJjSu2iFn/kqtHTIImswcY=
 github.com/btcsuite/btcd/btcec/v2 v2.2.1 h1:xP60mv8fvp+0khmrN0zTdPC3cNm24rfeE6lh2R/Yv3E=
@@ -414,6 +419,7 @@ github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537 h1:YGaxtkYjb8mnTvtufv2LKLwCQu2/C7qFB7UtrOlTWOY=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133 h1:JtcyT0rk/9PKOdnKQzuDR+FSjh7SGtJwpgVpfZBRKlQ=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/sosodev/duration v1.3.1 h1:qtHBDMQ6lvMQsL15g4aopM4HEfOaYuhWBw3NPTtlqq4=
 github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9Ev6lojP2XaIshpT4ymkqhMeSghO5Ps00E=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/packages/cache/cache.go
+++ b/packages/cache/cache.go
@@ -4,6 +4,7 @@ package cache
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	"github.com/VictoriaMetrics/fastcache"
 )
@@ -51,7 +52,7 @@ var (
 	mutex = &sync.Mutex{}
 
 	// the fastcache
-	cache *fastcache.Cache
+	cache atomic.Pointer[fastcache.Cache]
 )
 
 // SetCacheSize sets the cache size
@@ -74,34 +75,36 @@ func GetStats() *Stats {
 	defer mutex.Unlock()
 
 	// cache disabled
-	if cache == nil {
+	fc := cache.Load()
+	if fc == nil {
 		return nil
 	}
 
 	stats := &fastcache.Stats{}
-	cache.UpdateStats(stats)
+	fc.UpdateStats(stats)
 	return &Stats{
 		Stats:      stats,
 		NumHandles: handleCounter,
 	}
 }
 
-// NewCacheParition creates a new cache partition
+// NewCachePartition creates a new cache partition
 // initializes the cache if not already happened
-func NewCacheParition() (CacheInterface, error) {
+func NewCachePartition() (CacheInterface, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	// initialize the cache first time it is used
 	if cacheSize != 0 {
 		initOnce.Do(func() {
-			cache = fastcache.New(cacheSize)
+			cache.Store(fastcache.New(cacheSize))
 		})
 	}
 
+	fc := cache.Load()
 	// if cache disabled or we used all handles
 	// return a cache (as failsafe) that does nothing
-	if cache == nil || handleCounter >= (1<<(partitionSize*8))-1 {
+	if fc == nil || handleCounter >= (1<<(partitionSize*8))-1 {
 		return &CacheNoop{}, nil
 	}
 
@@ -130,9 +133,17 @@ func (c *CacheNoop) Add(key []byte, value []byte) {
 }
 
 func (c *CachePartition) Get(key []byte) ([]byte, bool) {
-	return cache.HasGet(nil, append(c.partition[:], key...))
+	fc := cache.Load()
+	if fc == nil {
+		return nil, false
+	}
+	return fc.HasGet(nil, append(c.partition[:], key...))
 }
 
 func (c *CachePartition) Add(key []byte, value []byte) {
-	cache.Set(append(c.partition[:], key...), value)
+	fc := cache.Load()
+	if fc == nil {
+		return
+	}
+	fc.Set(append(c.partition[:], key...), value)
 }

--- a/packages/cache/cache.go
+++ b/packages/cache/cache.go
@@ -4,7 +4,6 @@ package cache
 import (
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/VictoriaMetrics/fastcache"
 )
@@ -52,7 +51,7 @@ var (
 	mutex = &sync.Mutex{}
 
 	// the fastcache
-	cache atomic.Pointer[fastcache.Cache]
+	cache *fastcache.Cache
 )
 
 // SetCacheSize sets the cache size
@@ -75,13 +74,12 @@ func GetStats() *Stats {
 	defer mutex.Unlock()
 
 	// cache disabled
-	fc := cache.Load()
-	if fc == nil {
+	if cache == nil {
 		return nil
 	}
 
 	stats := &fastcache.Stats{}
-	fc.UpdateStats(stats)
+	cache.UpdateStats(stats)
 	return &Stats{
 		Stats:      stats,
 		NumHandles: handleCounter,
@@ -97,14 +95,13 @@ func NewCachePartition() (CacheInterface, error) {
 	// initialize the cache first time it is used
 	if cacheSize != 0 {
 		initOnce.Do(func() {
-			cache.Store(fastcache.New(cacheSize))
+			cache = fastcache.New(cacheSize)
 		})
 	}
 
-	fc := cache.Load()
 	// if cache disabled or we used all handles
 	// return a cache (as failsafe) that does nothing
-	if fc == nil || handleCounter >= (1<<(partitionSize*8))-1 {
+	if cache == nil || handleCounter >= (1<<(partitionSize*8))-1 {
 		return &CacheNoop{}, nil
 	}
 
@@ -133,17 +130,9 @@ func (c *CacheNoop) Add(key []byte, value []byte) {
 }
 
 func (c *CachePartition) Get(key []byte) ([]byte, bool) {
-	fc := cache.Load()
-	if fc == nil {
-		return nil, false
-	}
-	return fc.HasGet(nil, append(c.partition[:], key...))
+	return cache.HasGet(nil, append(c.partition[:], key...))
 }
 
 func (c *CachePartition) Add(key []byte, value []byte) {
-	fc := cache.Load()
-	if fc == nil {
-		return
-	}
-	fc.Set(append(c.partition[:], key...), value)
+	cache.Set(append(c.partition[:], key...), value)
 }

--- a/packages/chain/node_test.go
+++ b/packages/chain/node_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/iotaledger/wasp/v2/packages/testutil/l1starter"
 	"github.com/iotaledger/wasp/v2/packages/testutil/testchain"
 	"github.com/iotaledger/wasp/v2/packages/testutil/testlogger"
+	"github.com/iotaledger/wasp/v2/packages/testutil/testmisc"
 	"github.com/iotaledger/wasp/v2/packages/testutil/testpeers"
 	"github.com/iotaledger/wasp/v2/packages/transaction"
 	"github.com/iotaledger/wasp/v2/packages/vm/core/accounts"
@@ -68,12 +69,12 @@ func TestMain(m *testing.M) {
 func TestNodeBasic(t *testing.T) {
 	t.Parallel()
 	tests := []tc{
-		{n: 1, f: 0, reliable: true, timeout: 30 * time.Second},   // Low N
-		{n: 2, f: 0, reliable: true, timeout: 40 * time.Second},   // Low N
-		{n: 3, f: 0, reliable: true, timeout: 50 * time.Second},   // Low N
-		{n: 4, f: 0, reliable: true, timeout: 100 * time.Second},  // Minimal robust config.
-		{n: 4, f: 1, reliable: true, timeout: 100 * time.Second},  // Minimal robust config.
-		{n: 10, f: 3, reliable: true, timeout: 150 * time.Second}, // Typical config.
+		{n: 1, f: 0, reliable: true, timeout: 60 * time.Second},   // Low N
+		{n: 2, f: 0, reliable: true, timeout: 60 * time.Second},   // Low N
+		{n: 3, f: 0, reliable: true, timeout: 60 * time.Second},   // Low N
+		{n: 4, f: 0, reliable: true, timeout: 120 * time.Second},  // Minimal robust config.
+		{n: 4, f: 1, reliable: true, timeout: 120 * time.Second},  // Minimal robust config.
+		{n: 10, f: 3, reliable: true, timeout: 180 * time.Second}, // Typical config.
 	}
 	if !testing.Short() {
 		tests = append(tests,
@@ -96,7 +97,7 @@ func testNodeBasic(t *testing.T, n, f int, reliable bool, timeout time.Duration,
 	te := newEnv(t, n, f, reliable, node)
 	defer te.close()
 
-	ctxTimeout, ctxTimeoutCancel := context.WithTimeout(te.ctx, timeout)
+	ctxTimeout, ctxTimeoutCancel := context.WithTimeout(te.ctx, testmisc.GetTimeout(timeout))
 	defer ctxTimeoutCancel()
 
 	te.log.LogDebugf("All started.")
@@ -107,7 +108,7 @@ func testNodeBasic(t *testing.T, n, f int, reliable bool, timeout time.Duration,
 
 	// Create SC L1Client account with some deposit
 	scClient := cryptolib.NewKeyPair()
-	err := te.l1Client.RequestFunds(context.Background(), *scClient.Address())
+	err := te.l1Client.RequestFunds(ctxTimeout, *scClient.Address())
 	require.NoError(t, err)
 
 	//
@@ -145,7 +146,7 @@ func testNodeBasic(t *testing.T, n, f int, reliable bool, timeout time.Duration,
 		require.NoError(t, err)
 		reqRef, err := req.GetCreatedObjectByName(iscmove.RequestModuleName, iscmove.RequestObjectName)
 		require.NoError(t, err)
-		reqWithObj, err := te.l2Client.GetRequestFromObjectID(context.Background(), reqRef.ObjectID)
+		reqWithObj, err := te.l2Client.GetRequestFromObjectID(ctxTimeout, reqRef.ObjectID)
 		require.NoError(t, err)
 
 		incRequests[i] = *reqWithObj

--- a/packages/evm/evmlogger/evmlogger.go
+++ b/packages/evm/evmlogger/evmlogger.go
@@ -4,19 +4,14 @@ package evmlogger
 import (
 	"context"
 	"log/slog"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
 
 	hiveLog "github.com/iotaledger/hive.go/log"
 )
 
-var initOnce sync.Once
-
 func Init(hiveLogger hiveLog.Logger) {
-	initOnce.Do(func() {
-		log.SetDefault(log.NewLogger(&hiveLogHandler{hiveLogger}))
-	})
+	log.SetDefault(log.NewLogger(&hiveLogHandler{hiveLogger}))
 }
 
 type hiveLogHandler struct{ hiveLog.Logger }

--- a/packages/evm/evmlogger/evmlogger.go
+++ b/packages/evm/evmlogger/evmlogger.go
@@ -4,14 +4,19 @@ package evmlogger
 import (
 	"context"
 	"log/slog"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
 
 	hiveLog "github.com/iotaledger/hive.go/log"
 )
 
+var initOnce sync.Once
+
 func Init(hiveLogger hiveLog.Logger) {
-	log.SetDefault(log.NewLogger(&hiveLogHandler{hiveLogger}))
+	initOnce.Do(func() {
+		log.SetDefault(log.NewLogger(&hiveLogHandler{hiveLogger}))
+	})
 }
 
 type hiveLogHandler struct{ hiveLog.Logger }

--- a/packages/evm/evmlogger/evmlogger.go
+++ b/packages/evm/evmlogger/evmlogger.go
@@ -4,14 +4,19 @@ package evmlogger
 import (
 	"context"
 	"log/slog"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
 
 	hiveLog "github.com/iotaledger/hive.go/log"
 )
 
+var initOnce sync.Once
+
 func Init(hiveLogger hiveLog.Logger) {
-	log.SetDefault(log.NewLogger(&hiveLogHandler{hiveLogger}))
+	initOnce.Do(func() {
+		log.SetDefault(log.NewLogger(&hiveLogHandler{hiveLog.NewLogger()}))
+	})
 }
 
 type hiveLogHandler struct{ hiveLog.Logger }

--- a/packages/kv/cached.go
+++ b/packages/kv/cached.go
@@ -13,7 +13,7 @@ type cachedKVStoreReader struct {
 // IMPORTANT: there is no logic for cache invalidation, so make sure that the
 // underlying KVStoreReader is never mutated.
 func NewCachedKVStoreReader(r KVStoreReader) KVStoreReader {
-	cache, err := cache.NewCacheParition()
+	cache, err := cache.NewCachePartition()
 	if err != nil {
 		panic(err)
 	}

--- a/packages/solo/clock.go
+++ b/packages/solo/clock.go
@@ -9,12 +9,16 @@ import (
 
 // GlobalTime return current logical clock time on the 'solo' instance
 func (env *Solo) GlobalTime() time.Time {
+	env.mockTimeMutex.RLock()
+	defer env.mockTimeMutex.RUnlock()
 	return env.mockTime
 }
 
 // AdvanceClockBy advances logical clock by time step
 func (env *Solo) AdvanceClockBy(step time.Duration) {
+	env.mockTimeMutex.Lock()
 	env.mockTime = env.mockTime.Add(step)
+	env.mockTimeMutex.Unlock()
 	env.logger.LogInfof("AdvanceClockBy: logical clock advanced by %v to %s",
 		step, env.GlobalTime().Format(timeLayout))
 }

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -33,7 +33,6 @@ import (
 	"github.com/iotaledger/wasp/v2/packages/origin"
 	"github.com/iotaledger/wasp/v2/packages/parameters"
 	"github.com/iotaledger/wasp/v2/packages/publisher"
-	"github.com/iotaledger/wasp/v2/packages/state"
 	"github.com/iotaledger/wasp/v2/packages/state/indexedstore"
 	"github.com/iotaledger/wasp/v2/packages/state/statetest"
 	"github.com/iotaledger/wasp/v2/packages/testutil/l1starter"
@@ -269,9 +268,7 @@ func (env *Solo) WithWaitForNextVersion(currentRef *iotago.ObjectRef, cb func())
 	return env.L1Client().WaitForNextVersionForTesting(context.Background(), testmisc.GetTimeout(30*time.Second), env.logger, currentRef, cb)
 }
 
-func (env *Solo) deployChain(chainAdmin *cryptolib.KeyPair, initCommonAccountBaseTokens coin.Value, name string, evmChainID uint16, blockKeepAmount int32) chainData {
-	env.logger.LogDebugf("deploying new chain '%s'", name)
-
+func (env *Solo) getChainIdentities(chainAdmin *cryptolib.KeyPair) (*cryptolib.KeyPair, *cryptolib.KeyPair) {
 	env.chainsMutex.RLock()
 	chainsLen := len(env.chains)
 	env.chainsMutex.RUnlock()
@@ -283,34 +280,15 @@ func (env *Solo) deployChain(chainAdmin *cryptolib.KeyPair, initCommonAccountBas
 
 	anchorOwner := env.NewKeyPairFromIndex(-2000 + chainsLen)
 	env.GetFundsFromFaucet(anchorOwner.Address())
+	return chainAdmin, anchorOwner
+}
 
-	initParams := origin.NewInitParams(
-		isc.NewAddressAgentID(chainAdmin.Address()),
-		evmChainID,
-		blockKeepAmount,
-		true,
-	)
-
-	schemaVersion := allmigrations.DefaultScheme.LatestSchemaVersion()
-	db := mapdb.NewMapDB()
-	store := indexedstore.New(statetest.NewStoreWithUniqueWriteMutex(db))
-
-	gasCoinRef := env.makeBaseTokenCoin(anchorOwner, isc.GasCoinTargetValue, nil)
-	env.logger.LogInfof("Chain Originator address: %v\n", anchorOwner)
-	env.logger.LogInfof("GAS COIN BEFORE PULL: %v\n", gasCoinRef)
-
-	var block state.Block
-	var stateMetadata *transaction.StateMetadata
-
-	block, stateMetadata = origin.InitChain(
-		schemaVersion,
-		store,
-		initParams.Encode(),
-		*gasCoinRef.ObjectID,
-		initCommonAccountBaseTokens,
-		env.L1Params(),
-	)
-
+func (env *Solo) startChainOnL1(
+	anchorOwner *cryptolib.KeyPair,
+	stateMetadata *transaction.StateMetadata,
+	gasCoinRef *iotago.ObjectRef,
+	initCommonAccountBaseTokens coin.Value,
+) *iscmove.AnchorWithRef {
 	var initCoin *iotago.ObjectRef
 
 	if initCommonAccountBaseTokens > 0 {
@@ -353,6 +331,40 @@ func (env *Solo) deployChain(chainAdmin *cryptolib.KeyPair, initCommonAccountBas
 	})
 
 	require.NoError(env.T, err)
+	return anchorRef
+}
+
+func (env *Solo) deployChain(chainAdmin *cryptolib.KeyPair, initCommonAccountBaseTokens coin.Value, name string, evmChainID uint16, blockKeepAmount int32) chainData {
+	env.logger.LogDebugf("deploying new chain '%s'", name)
+
+	chainAdmin, anchorOwner := env.getChainIdentities(chainAdmin)
+
+	initParams := origin.NewInitParams(
+		isc.NewAddressAgentID(chainAdmin.Address()),
+		evmChainID,
+		blockKeepAmount,
+		true,
+	)
+
+	schemaVersion := allmigrations.DefaultScheme.LatestSchemaVersion()
+	db := mapdb.NewMapDB()
+	store := indexedstore.New(statetest.NewStoreWithUniqueWriteMutex(db))
+
+	gasCoinRef := env.makeBaseTokenCoin(anchorOwner, isc.GasCoinTargetValue, nil)
+	env.logger.LogInfof("Chain Originator address: %v\n", anchorOwner)
+	env.logger.LogInfof("GAS COIN BEFORE PULL: %v\n", gasCoinRef)
+
+	block, stateMetadata := origin.InitChain(
+		schemaVersion,
+		store,
+		initParams.Encode(),
+		*gasCoinRef.ObjectID,
+		initCommonAccountBaseTokens,
+		env.L1Params(),
+	)
+
+	anchorRef := env.startChainOnL1(anchorOwner, stateMetadata, gasCoinRef, initCommonAccountBaseTokens)
+
 	chainID := isc.ChainIDFromObjectID(anchorRef.Object.ID)
 
 	env.logger.LogInfof(

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -272,12 +272,16 @@ func (env *Solo) WithWaitForNextVersion(currentRef *iotago.ObjectRef, cb func())
 func (env *Solo) deployChain(chainAdmin *cryptolib.KeyPair, initCommonAccountBaseTokens coin.Value, name string, evmChainID uint16, blockKeepAmount int32) chainData {
 	env.logger.LogDebugf("deploying new chain '%s'", name)
 
+	env.chainsMutex.RLock()
+	chainsLen := len(env.chains)
+	env.chainsMutex.RUnlock()
+
 	if chainAdmin == nil {
-		chainAdmin = env.NewKeyPairFromIndex(-1000 + len(env.chains)) // making new originator for each new chain
+		chainAdmin = env.NewKeyPairFromIndex(-1000 + chainsLen) // making new originator for each new chain
 		env.GetFundsFromFaucet(chainAdmin.Address())
 	}
 
-	anchorOwner := env.NewKeyPairFromIndex(-2000 + len(env.chains))
+	anchorOwner := env.NewKeyPairFromIndex(-2000 + chainsLen)
 	env.GetFundsFromFaucet(anchorOwner.Address())
 
 	initParams := origin.NewInitParams(

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -38,6 +38,7 @@ import (
 	"github.com/iotaledger/wasp/v2/packages/state/statetest"
 	"github.com/iotaledger/wasp/v2/packages/testutil/l1starter"
 	"github.com/iotaledger/wasp/v2/packages/testutil/testlogger"
+	"github.com/iotaledger/wasp/v2/packages/testutil/testmisc"
 	"github.com/iotaledger/wasp/v2/packages/transaction"
 	"github.com/iotaledger/wasp/v2/packages/vm"
 	"github.com/iotaledger/wasp/v2/packages/vm/core/coreprocessors"
@@ -265,7 +266,7 @@ func (env *Solo) MustWithWaitForNextVersion(currentRef *iotago.ObjectRef, cb fun
 // This tries to make sure that an object meant to be used multiple times, does not get referenced twice with the same ref.
 // Handle with care. Only use it on objects that are expected to be used again, like a GasCoin/Generic coin/Requests
 func (env *Solo) WithWaitForNextVersion(currentRef *iotago.ObjectRef, cb func()) (*iotago.ObjectRef, error) {
-	return env.L1Client().WaitForNextVersionForTesting(context.Background(), 30*time.Second, env.logger, currentRef, cb)
+	return env.L1Client().WaitForNextVersionForTesting(context.Background(), testmisc.GetTimeout(30*time.Second), env.logger, currentRef, cb)
 }
 
 func (env *Solo) deployChain(chainAdmin *cryptolib.KeyPair, initCommonAccountBaseTokens coin.Value, name string, evmChainID uint16, blockKeepAmount int32) chainData {

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -67,6 +67,8 @@ type Solo struct {
 	publisher            *publisher.Publisher
 	ctx                  context.Context
 	mockTime             time.Time
+	mockTimeMutex        sync.RWMutex
+	publisherWG          sync.WaitGroup
 	l1ParamsFetcher      parameters.L1ParamsFetcher
 
 	l1Config L1Config
@@ -158,7 +160,6 @@ func New(t Context, initOptions ...*InitOptions) *Solo {
 	}
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
-	t.Cleanup(cancelCtx)
 
 	ret := &Solo{
 		T:                    t,
@@ -176,7 +177,14 @@ func New(t Context, initOptions ...*InitOptions) *Solo {
 		ret.logger.LogInfof("solo publisher: %s %s %v", ev.Kind, ev.ChainID, ev.String())
 	})
 
-	go ret.publisher.Run(ctx)
+	ret.publisherWG.Add(1)
+	go func() {
+		defer ret.publisherWG.Done()
+		ret.publisher.Run(ctx)
+	}()
+
+	t.Cleanup(ret.publisherWG.Wait)
+	t.Cleanup(cancelCtx)
 
 	return ret
 }

--- a/packages/trie/kv_cached.go
+++ b/packages/trie/kv_cached.go
@@ -10,7 +10,7 @@ type cachedKVReader struct {
 }
 
 func makeCachedKVReader(r KVReader) KVReader {
-	cache, err := cache.NewCacheParition()
+	cache, err := cache.NewCachePartition()
 	if err != nil {
 		panic(err)
 	}

--- a/packages/vm/core/testcore/accounts_test.go
+++ b/packages/vm/core/testcore/accounts_test.go
@@ -200,11 +200,13 @@ func (v *accountsDepositTest) printBalances(prefix string) {
 func TestAccounts_WithdrawDepositCoins(t *testing.T) {
 	t.Parallel()
 	t.Run("withdraw with empty", func(t *testing.T) {
+		t.Parallel()
 		v := initWithdrawTest(t)
 		_, err := v.ch.PostRequestSync(v.req, v.user)
 		testmisc.RequireErrorToBe(t, err, "not enough allowance")
 	})
 	t.Run("withdraw almost all", func(t *testing.T) {
+		t.Parallel()
 		v := initWithdrawTest(t)
 		toWithdraw := v.ch.L2Assets(v.userAgentID)
 		t.Logf("assets to withdraw: %s", toWithdraw.String())
@@ -218,6 +220,7 @@ func TestAccounts_WithdrawDepositCoins(t *testing.T) {
 	})
 
 	t.Run("accounting and pruning", func(t *testing.T) {
+		t.Parallel()
 		// mint 100 tokens from chain 1 and withdraw those to L1
 		v := initWithdrawTest(t)
 

--- a/packages/vm/core/testcore/accounts_test.go
+++ b/packages/vm/core/testcore/accounts_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestAccounts_Deposit(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	sender, _ := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	ch := env.NewChain()
@@ -36,6 +37,7 @@ func TestAccounts_Deposit(t *testing.T) {
 }
 
 func TestAccounts_DepositWithObject(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	sender, _ := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	ch := env.NewChain()
@@ -52,6 +54,7 @@ func TestAccounts_DepositWithObject(t *testing.T) {
 
 // allowance shouldn't allow you to bypass gas fees.
 func TestAccounts_DepositCheatAllowance(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	sender, senderAddr := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	senderAgentID := isc.NewAddressAgentID(senderAddr)
@@ -76,6 +79,7 @@ func TestAccounts_DepositCheatAllowance(t *testing.T) {
 }
 
 func TestAccounts_WithdrawEverything(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	sender, senderAddr := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	senderAgentID := isc.NewAddressAgentID(senderAddr)
@@ -194,6 +198,7 @@ func (v *accountsDepositTest) printBalances(prefix string) {
 }
 
 func TestAccounts_WithdrawDepositCoins(t *testing.T) {
+	t.Parallel()
 	t.Run("withdraw with empty", func(t *testing.T) {
 		v := initWithdrawTest(t)
 		_, err := v.ch.PostRequestSync(v.req, v.user)
@@ -238,6 +243,7 @@ func TestAccounts_WithdrawDepositCoins(t *testing.T) {
 }
 
 func TestAccounts_TransferAndCheckBaseTokens(t *testing.T) {
+	t.Parallel()
 	// initializes it all and prepares withdraw request, does not post it
 	v := initWithdrawTest(t)
 	initialCommonAccountBaseTokens := v.ch.L2CommonAccountAssets().BaseTokens()
@@ -254,6 +260,7 @@ func TestAccounts_TransferAndCheckBaseTokens(t *testing.T) {
 }
 
 func TestAccounts_TransferPartialAssets(t *testing.T) {
+	t.Parallel()
 	// setup a chain with some base tokens and native tokens for user1
 	v := initWithdrawTest(t)
 	v.ch.MustDepositBaseTokensToL2(solo.BaseTokensForL2Gas, v.ch.ChainAdmin)
@@ -291,6 +298,7 @@ func TestAccounts_TransferPartialAssets(t *testing.T) {
 }
 
 func TestAccounts_DepositRandomContractMinFee(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	ch := env.NewChain()
 
@@ -308,6 +316,7 @@ func TestAccounts_DepositRandomContractMinFee(t *testing.T) {
 }
 
 func TestAccounts_AllowanceNotEnoughFunds(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	ch := env.NewChain()
 
@@ -336,6 +345,7 @@ func TestAccounts_AllowanceNotEnoughFunds(t *testing.T) {
 }
 
 func TestAccounts_DepositWithNoGasBudget(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	senderWallet, _ := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	ch := env.NewChain()
@@ -357,6 +367,7 @@ func TestAccounts_DepositWithNoGasBudget(t *testing.T) {
 }
 
 func TestAccounts_RequestWithNoGasBudget(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	ch := env.NewChain()
 	senderWallet, _ := env.NewKeyPairWithFunds()
@@ -379,6 +390,7 @@ func TestAccounts_RequestWithNoGasBudget(t *testing.T) {
 }
 
 func TestAccounts_Nonces(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	ch := env.NewChain()
 	senderWallet, _ := env.NewKeyPairWithFunds()
@@ -418,6 +430,7 @@ func TestAccounts_Nonces(t *testing.T) {
 }
 
 func TestAccounts_AdjustCommonAccountBaseTokens(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{})
 	sender, _ := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	ch := env.NewChain()

--- a/packages/vm/core/testcore/base_test.go
+++ b/packages/vm/core/testcore/base_test.go
@@ -189,6 +189,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			env := solo.New(t, &solo.InitOptions{
 				Debug:           true,
 				PrintStackTrace: true,
@@ -262,12 +263,14 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 func TestNoTargetView(t *testing.T) {
 	t.Parallel()
 	t.Run("no contract view", func(t *testing.T) {
+		t.Parallel()
 		env := solo.New(t)
 		chain := env.NewChain()
 		_, err := chain.CallViewEx("dummyContract", "dummyEP")
 		require.Error(t, err)
 	})
 	t.Run("no EP view", func(t *testing.T) {
+		t.Parallel()
 		env := solo.New(t)
 		chain := env.NewChain()
 		_, err := chain.CallViewEx(root.Contract.Name, "dummyEP")
@@ -359,6 +362,7 @@ func TestEstimateGas(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.Desc, func(t *testing.T) {
+			t.Parallel()
 			keyPair, addr := env.NewKeyPairWithFunds()
 			agentID := isc.NewAddressAgentID(addr)
 

--- a/packages/vm/core/testcore/base_test.go
+++ b/packages/vm/core/testcore/base_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestInitLoad(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	user, userAddr := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	env.AssertL1BaseTokens(userAddr, iotaclient.FundsFromFaucetAmount)
@@ -45,6 +46,7 @@ func TestInitLoad(t *testing.T) {
 
 // TestLedgerBaseConsistency deploys chain and check consistency of L1 and L2 ledgers
 func TestLedgerBaseConsistency(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{
 		Debug:           true,
 		PrintStackTrace: true,
@@ -64,6 +66,7 @@ func TestLedgerBaseConsistency(t *testing.T) {
 
 // TestLedgerBaseConsistencyWithRequiredTopUpFee deploys a chain and checks the consistency of L1 and L2 ledgers after topping up fees
 func TestLedgerBaseConsistencyWithRequiredTopUpFee(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{
 		Debug:           true,
 		PrintStackTrace: true,
@@ -153,6 +156,7 @@ func TestLedgerBaseConsistencyWithRequiredTopUpFee(t *testing.T) {
 
 // TestNoTargetPostOnLedger test what happens when sending requests to non-existent contract or entry point
 func TestNoTargetPostOnLedger(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		Name               string
 		Req                *solo.CallParams
@@ -256,6 +260,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 }
 
 func TestNoTargetView(t *testing.T) {
+	t.Parallel()
 	t.Run("no contract view", func(t *testing.T) {
 		env := solo.New(t)
 		chain := env.NewChain()
@@ -271,6 +276,7 @@ func TestNoTargetView(t *testing.T) {
 }
 
 func TestSandboxStackOverflow(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("short mode")
 	}
@@ -289,6 +295,7 @@ func TestSandboxStackOverflow(t *testing.T) {
 }
 
 func TestEstimateGas(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 	ch.MustDepositBaseTokensToL2(10000, nil)
@@ -388,6 +395,7 @@ func TestEstimateGas(t *testing.T) {
 }
 
 func TestFeeBasic(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	chain := env.NewChain()
 	feePolicy := chain.GetGasFeePolicy()
@@ -395,6 +403,7 @@ func TestFeeBasic(t *testing.T) {
 }
 
 func TestBurnLog(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -409,6 +418,7 @@ func TestBurnLog(t *testing.T) {
 }
 
 func TestMessageSize(t *testing.T) {
+	t.Parallel()
 	t.Skipf("This test needs to be properly validated and fixed. Its only temporarily deactivated.")
 
 	env := solo.New(t, &solo.InitOptions{
@@ -458,6 +468,7 @@ func TestMessageSize(t *testing.T) {
 }
 
 func TestInvalidSignatureRequestsAreNotProcessed(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -476,6 +487,7 @@ func TestInvalidSignatureRequestsAreNotProcessed(t *testing.T) {
 }
 
 func TestInvalidAllowance(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -505,6 +517,7 @@ func TestInvalidAllowance(t *testing.T) {
 }
 
 func TestBatchWithSkippedRequestsReceipts(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 	user, _ := env.NewKeyPairWithFunds()

--- a/packages/vm/core/testcore/blocklog_test.go
+++ b/packages/vm/core/testcore/blocklog_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestBlocklog_BlockInfoLatest(t *testing.T) {
+	t.Parallel()
 	corecontracts.PrintWellKnownHnames()
 	env := solo.New(t)
 	chain := env.NewChain()
@@ -29,6 +30,7 @@ func TestBlocklog_BlockInfoLatest(t *testing.T) {
 }
 
 func TestBlocklog_BlockInfo(t *testing.T) {
+	t.Parallel()
 	corecontracts.PrintWellKnownHnames()
 	env := solo.New(t)
 	chain := env.NewChain()
@@ -53,6 +55,7 @@ func TestBlocklog_BlockInfo(t *testing.T) {
 }
 
 func TestBlocklog_BlockInfoLatestWithRequest(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 
 	ch := env.NewChain()
@@ -73,6 +76,7 @@ func TestBlocklog_BlockInfoLatestWithRequest(t *testing.T) {
 }
 
 func TestBlocklog_BlockInfoSeveral(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -98,6 +102,7 @@ func TestBlocklog_BlockInfoSeveral(t *testing.T) {
 }
 
 func TestBlocklog_RequestIsProcessed(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -118,6 +123,7 @@ func TestBlocklog_RequestIsProcessed(t *testing.T) {
 }
 
 func TestBlocklog_RequestReceipt(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -143,6 +149,7 @@ func TestBlocklog_RequestReceipt(t *testing.T) {
 }
 
 func TestBlocklog_RequestReceiptsForBlocks(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -165,6 +172,7 @@ func TestBlocklog_RequestReceiptsForBlocks(t *testing.T) {
 }
 
 func TestBlocklog_RequestIDsForBlocks(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -185,6 +193,7 @@ func TestBlocklog_RequestIDsForBlocks(t *testing.T) {
 }
 
 func TestBlocklog_ViewGetRequestReceipt(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 	// try to get a receipt for a request that does not exist
@@ -193,6 +202,7 @@ func TestBlocklog_ViewGetRequestReceipt(t *testing.T) {
 }
 
 func TestBlocklog_Pruning(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{Debug: true})
 
 	ch, _ := env.NewChainExt(nil, 0, "chain1", 0, 10)

--- a/packages/vm/core/testcore/errors_test.go
+++ b/packages/vm/core/testcore/errors_test.go
@@ -37,6 +37,7 @@ func setupErrorsTest(t *testing.T) *solo.Chain {
 // Panicked vmerrors will be stored as is.
 
 func TestUntypedError(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	_, _, _, _, err := chain.PostRequestSyncTx(
@@ -51,6 +52,7 @@ func TestUntypedError(t *testing.T) {
 
 // This test does not supply the required kv pair 'ParamErrorMessageFormat' which makes the kvdecoder fail with an xerror
 func TestPanicDueMissingErrorMessage(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	req := solo.NewCallParamsEx(errors.Contract.Name, errors.FuncRegisterError.Name).
@@ -68,6 +70,7 @@ func TestPanicDueMissingErrorMessage(t *testing.T) {
 }
 
 func TestSuccessfulRegisterError(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	req := solo.NewCallParams(errors.FuncRegisterError.Message("poof")).
@@ -80,6 +83,7 @@ func TestSuccessfulRegisterError(t *testing.T) {
 }
 
 func TestRetrievalOfErrorMessage(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	errorCode, err := errors.FuncRegisterError.Call(testerrors.MessageToTest, func(msg isc.Message) (isc.CallArguments, error) {
@@ -103,6 +107,7 @@ func TestRetrievalOfErrorMessage(t *testing.T) {
 }
 
 func TestErrorRegistrationWithCustomContract(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	req := solo.NewCallParams(testerrors.FuncRegisterErrors.Message(nil)).
@@ -116,6 +121,7 @@ func TestErrorRegistrationWithCustomContract(t *testing.T) {
 }
 
 func TestPanicWithCustomContractWithArgs(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	// Register error
@@ -143,6 +149,7 @@ func TestPanicWithCustomContractWithArgs(t *testing.T) {
 }
 
 func TestPanicWithCustomContractWithoutArgs(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	// Register error
@@ -175,6 +182,7 @@ func TestPanicWithCustomContractWithoutArgs(t *testing.T) {
 }
 
 func TestUnresolvedErrorIsStoredInReceiptAndIsEqualToVMErrorWithoutArgs(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	// Register error
@@ -208,6 +216,7 @@ func TestUnresolvedErrorIsStoredInReceiptAndIsEqualToVMErrorWithoutArgs(t *testi
 }
 
 func TestUnresolvedErrorIsStoredInReceiptAndIsEqualToVMErrorWithArgs(t *testing.T) {
+	t.Parallel()
 	chain := setupErrorsTest(t)
 
 	// Register error
@@ -240,6 +249,7 @@ func TestUnresolvedErrorIsStoredInReceiptAndIsEqualToVMErrorWithArgs(t *testing.
 }
 
 func TestIsComparer(t *testing.T) {
+	t.Parallel()
 	template := isc.NewVMErrorTemplate(isc.NewVMErrorCode(1234, 1), "fooBar")
 	vmerror := template.Create()
 	vmerrorUnresolved := vmerror.AsUnresolvedError()

--- a/packages/vm/core/testcore/events_test.go
+++ b/packages/vm/core/testcore/events_test.go
@@ -54,6 +54,7 @@ func getBurnedGas(ch *solo.Chain, reqID isc.RequestID, err error) (uint64, error
 }
 
 func TestManyEvents(t *testing.T) {
+	t.Parallel()
 	ch := setupTest(t)
 
 	postEvents := func(n uint32) (uint64, error) {
@@ -89,6 +90,7 @@ func TestManyEvents(t *testing.T) {
 }
 
 func TestEventTooLarge(t *testing.T) {
+	t.Parallel()
 	ch := setupTest(t)
 
 	postEvent := func(n uint32) (uint64, error) {
@@ -138,6 +140,7 @@ func getEventsForBlock(t *testing.T, chain *solo.Chain, blockNumber ...uint32) [
 }
 
 func TestGetEvents(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 

--- a/packages/vm/core/testcore/governance_test.go
+++ b/packages/vm/core/testcore/governance_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestGovernanceAccessNodes(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	node1KP, _ := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
 	node1OwnerKP, node1OwnerAddr := env.NewKeyPairWithFunds(env.NewSeedFromTestNameAndTimestamp(t.Name()))
@@ -102,6 +103,7 @@ func TestGovernanceAccessNodes(t *testing.T) {
 }
 
 func TestMaintenanceMode(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -237,6 +239,7 @@ func TestMaintenanceMode(t *testing.T) {
 }
 
 func TestGovernanceMetadata(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain(true)
 
@@ -327,6 +330,7 @@ func TestGovernanceMetadata(t *testing.T) {
 }
 
 func TestGovernanceL1Metadata(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain()
 
@@ -390,6 +394,7 @@ func TestGovernanceL1Metadata(t *testing.T) {
 }
 
 func TestGovernanceGasFee(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{Debug: true, PrintStackTrace: true})
 	ch := env.NewChain()
 	fp := ch.GetGasFeePolicy()
@@ -400,6 +405,7 @@ func TestGovernanceGasFee(t *testing.T) {
 }
 
 func TestGovernanceZeroGasFee(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{Debug: true, PrintStackTrace: true})
 	ch := env.NewChain()
 
@@ -467,6 +473,7 @@ func TestGovernanceZeroGasFee(t *testing.T) {
 }
 
 func TestGovernanceSetMustGetPayoutAgentID(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{Debug: true, PrintStackTrace: true})
 	ch := env.NewChain()
 
@@ -496,6 +503,7 @@ func TestGovernanceSetMustGetPayoutAgentID(t *testing.T) {
 }
 
 func TestGovernanceGasCoinTargetValue(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{Debug: true, PrintStackTrace: true})
 	ch := env.NewChain()
 	initRetDict, err := ch.CallView(governance.ViewGetGasCoinTargetValue.Message())
@@ -520,6 +528,7 @@ func TestGovernanceGasCoinTargetValue(t *testing.T) {
 }
 
 func TestGovernanceCallsNoBalance(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	ch := env.NewChain(false)
 
@@ -537,6 +546,7 @@ func TestGovernanceCallsNoBalance(t *testing.T) {
 }
 
 func TestGovernanceGasPayout(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{
 		Debug:           true,
 		PrintStackTrace: true,

--- a/packages/vm/core/testcore/root_test.go
+++ b/packages/vm/core/testcore/root_test.go
@@ -22,12 +22,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestRootBasic(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	chain := env.NewChain()
 	chain.CheckChain()
 }
 
 func TestEntryPointNotFound(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	chain := env.NewChain()
 
@@ -39,6 +41,7 @@ func TestEntryPointNotFound(t *testing.T) {
 }
 
 func TestGetInfo(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	chain := env.NewChain()
 
@@ -56,6 +59,7 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestChangeAdminAuthorized(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t, &solo.InitOptions{
 		Debug:           true,
 		PrintStackTrace: true,
@@ -88,6 +92,7 @@ func TestChangeAdminAuthorized(t *testing.T) {
 }
 
 func TestChangeAdminUnauthorized(t *testing.T) {
+	t.Parallel()
 	env := solo.New(t)
 	chain := env.NewChain()
 

--- a/packages/vm/core/testcore/sbtests/call_test.go
+++ b/packages/vm/core/testcore/sbtests/call_test.go
@@ -83,7 +83,7 @@ func TestCallFibonacciIndirect(t *testing.T) {
 	require.EqualValues(t, fibonacci(fiboN), ret)
 }
 
-func TestIndirectCallFibonacci(t *testing.T) { //nolint:dupl
+func TestIndirectCallFibonacci(t *testing.T) {
 	_, chain := setupChain(t)
 	setupTestSandboxSC(t, chain, nil)
 
@@ -107,7 +107,7 @@ func TestIndirectCallFibonacci(t *testing.T) { //nolint:dupl
 	require.EqualValues(t, 1, r)
 }
 
-func TestIndirectCallFibonacciIndirect(t *testing.T) { //nolint:dupl
+func TestIndirectCallFibonacciIndirect(t *testing.T) {
 	_, chain := setupChain(t)
 	setupTestSandboxSC(t, chain, nil)
 

--- a/packages/vm/core/testcore/sbtests/call_test.go
+++ b/packages/vm/core/testcore/sbtests/call_test.go
@@ -83,7 +83,7 @@ func TestCallFibonacciIndirect(t *testing.T) {
 	require.EqualValues(t, fibonacci(fiboN), ret)
 }
 
-func TestIndirectCallFibonacci(t *testing.T) {
+func TestIndirectCallFibonacci(t *testing.T) { //nolint:dupl
 	_, chain := setupChain(t)
 	setupTestSandboxSC(t, chain, nil)
 
@@ -107,7 +107,7 @@ func TestIndirectCallFibonacci(t *testing.T) {
 	require.EqualValues(t, 1, r)
 }
 
-func TestIndirectCallFibonacciIndirect(t *testing.T) {
+func TestIndirectCallFibonacciIndirect(t *testing.T) { //nolint:dupl
 	_, chain := setupChain(t)
 	setupTestSandboxSC(t, chain, nil)
 

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -125,7 +125,17 @@ func (clu *Cluster) NewKeyPairWithFunds() (*cryptolib.KeyPair, *cryptolib.Addres
 }
 
 func (clu *Cluster) RequestFunds(addr *cryptolib.Address) error {
-	return clu.l1.RequestFunds(context.Background(), *addr)
+	err := clu.l1.RequestFunds(context.Background(), *addr)
+	if err != nil {
+		return err
+	}
+
+	return Retry(func() error {
+		if clu.L1BaseTokens(addr) > 0 {
+			return nil
+		}
+		return errors.New("funds not available yet")
+	}, 10)
 }
 
 func (clu *Cluster) L1Client() clients.L1Client {
@@ -248,7 +258,6 @@ func (clu *Cluster) RunDistributedKeyGeneration(committeeNodes []int, threshold 
 		addr, err = apilib.RunDistributedKeyGeneration(context.Background(), client, peerPubKeys, threshold, timeout...)
 		return err
 	}, 5)
-
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cluster/tests/cluster.go
+++ b/tools/cluster/tests/cluster.go
@@ -44,6 +44,9 @@ func parseConfig() l1starter.L1EndpointConfig {
 // It is a private function because cluster tests cannot be run in parallel,
 // so all cluster tests MUST be in this same package.
 func newCluster(t *testing.T, opt ...waspClusterOpts) *cluster.Cluster {
+	if testing.Short() {
+		t.Skip("Skipping cluster tests in short mode")
+	}
 	dirname := "wasp-cluster"
 	var modifyNodesConfig cluster.ModifyNodesConfigFn
 

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestMissingRequests(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
 	clu := newCluster(t, waspClusterOpts{nNodes: 4})
 	cmt := []int{0, 1, 2, 3}
 	threshold := uint16(4)

--- a/tools/cluster/tests/pruning_test.go
+++ b/tools/cluster/tests/pruning_test.go
@@ -63,21 +63,17 @@ func TestPruning(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, txs, numRequests)
 
-	maxBlockIndex := initialBlockIndex + numRequests
-
 	archiveClient := env.EVMJSONRPClient(archiveClientIndex)
 	lightClient := env.EVMJSONRPClient(lightClientIndex)
 
-	finalBlockIndex := uint32(0)
 	bn, err := archiveClient.BlockNumber(context.Background())
 	require.NoError(t, err)
-	finalBlockIndex = uint32(bn)
-	require.Greater(t, maxBlockIndex, finalBlockIndex)
+	finalBlockIndex := uint32(bn)
 
 	t.Run("the block number is correct", func(t *testing.T) {
 		bn, err = lightClient.BlockNumber(context.Background())
 		require.NoError(t, err)
-		require.GreaterOrEqual(t, uint64(maxBlockIndex), bn)
+		require.GreaterOrEqual(t, uint64(finalBlockIndex), bn)
 	})
 
 	t.Run("eth_getlogs", func(t *testing.T) {
@@ -85,7 +81,7 @@ func TestPruning(t *testing.T) {
 		filterQuery := ethereum.FilterQuery{
 			Addresses: []common.Address{storageContractAddr},
 			FromBlock: big.NewInt(int64(initialBlockIndex + 1)),
-			ToBlock:   big.NewInt(int64(maxBlockIndex)),
+			ToBlock:   big.NewInt(int64(finalBlockIndex)),
 		}
 
 		// archive node

--- a/tools/cluster/tests/spam_test.go
+++ b/tools/cluster/tests/spam_test.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
-	"github.com/iotaledger/wasp/v2/clients/apiclient"
 	"github.com/iotaledger/wasp/v2/clients/chainclient"
 	"github.com/iotaledger/wasp/v2/clients/iota-go/iotaclient"
 	"github.com/iotaledger/wasp/v2/packages/coin"
@@ -23,21 +21,19 @@ import (
 
 // executed in cluster_test.go
 func (e *ChainEnv) testSpamEVM(t *testing.T) {
-	//TODO: increase to 10K as in original test. Now it's not passing
+	// TODO: increase to 10K as in original test. Now it's not passing
 	const numRequests = 600
 
 	numRequestsPerAccount := 100
 	numAccounts := numRequests / numRequestsPerAccount
 
-	var eg errgroup.Group
-	for range numAccounts {
-		eg.Go(func() error {
-			return e.checkNRequests(newClusterTestEnv(t, e, 0), int64(numRequestsPerAccount), 0, []int{0}, 30*time.Second)
+	for i := range numAccounts {
+		t.Run(fmt.Sprintf("account-%d", i), func(t *testing.T) {
+			t.Parallel()
+			err := e.checkNRequests(newClusterTestEnv(t, e, 0), int64(numRequestsPerAccount), 0, []int{0}, 30*time.Second)
+			require.NoError(t, err)
 		})
 	}
-
-	err := eg.Wait()
-	require.NoError(t, err)
 }
 
 // executed in cluster_test.go
@@ -90,15 +86,17 @@ func (e *ChainEnv) testSpamOnledger(t *testing.T) {
 				}
 				reqSentTime := time.Now()
 				// wait for the request to be processed
-				var receipt []*apiclient.ReceiptResponse
-				receipt, err = e.Chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(context.Background(), e.Chain.ChainID, req, false, 1*time.Minute)
-				if err != nil {
-					reqErrorChan <- err
+				receipt, er := e.Chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(context.Background(), e.Chain.ChainID, req, false, 1*time.Minute)
+				if er != nil {
+					reqErrorChan <- er
 					return
 				}
 
-				gasFeeCharged, err := util.DecodeUint64(receipt[0].GasFeeCharged)
-				require.NoError(t, err)
+				gasFeeCharged, er := util.DecodeUint64(receipt[0].GasFeeCharged)
+				if er != nil {
+					reqErrorChan <- er
+					return
+				}
 				wallets[walletIndex].gasChargedTotal.Add(gasFeeCharged)
 
 				processingDuration := uint64(time.Since(reqSentTime).Seconds())

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -263,7 +263,6 @@ func (e *ChainEnv) sendNRequests(clusterTestEnv *clusterTestEnv, numRequests int
 }
 
 func (e *ChainEnv) verifyNRequests(ctx context.Context, transactions chan *types.Transaction, numRequests int64, readNodeIndexes []int, storageContractAddr common.Address, cb func(tx *types.Transaction)) error {
-
 outer:
 	for {
 		select {
@@ -389,7 +388,6 @@ func newClusterTestEnv(t *testing.T, env *ChainEnv, nodeIndex int) *clusterTestE
 	rawClient, err := rpc.DialHTTP(jsonRPCEndpoint)
 	require.NoError(t, err)
 	client := ethclient.NewClient(rawClient)
-	t.Cleanup(client.Close)
 
 	waitTxConfirmed := func(txHash common.Hash) error {
 		c := env.Chain.Client(nil, nodeIndex)
@@ -417,7 +415,7 @@ func newClusterTestEnv(t *testing.T, env *ChainEnv, nodeIndex int) *clusterTestE
 			ChainID:         evm.DefaultChainID,
 			WaitTxConfirmed: waitTxConfirmed,
 		},
-		ChainEnv: *env,
+		ChainEnv: env,
 	}
 	e.Env.NewAccountWithL2Funds = e.newEthereumAccountWithL2Funds
 	return e
@@ -463,5 +461,5 @@ func (e *clusterTestEnv) newEthereumAccountWithL2Funds(baseTokens ...coin.Value)
 
 type clusterTestEnv struct {
 	jsonrpctest.Env
-	ChainEnv
+	*ChainEnv
 }


### PR DESCRIPTION
A bunch of misc fixes and tweaks for tests that would timeout, race conditions, etc. 

- Retry loop after requesting funds from faucet to give indexer time to catch up
- Retry loop calling client.GetCoins
- Add timeouts to graphql client for `TestQueryTransactionBlocks`
- Increased timeouts for `TestNodeBasic`
- A handful of tests marked as being able to run in parallel 