### PR TITLE
parallelize evmtest 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,6 @@ jobs:
           TEST_SHORT_PKGS="$(go list ./... \
             | grep -v '/packages/vm/core/testcore' \
             | grep -v '/tools/cluster' \
-            | grep -v '/packages/vm/core/evm/evmtest' \
             | grep -v '/packages/evm/jsonrpc/jsonrpctest' \
           )" make test-short
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test: install
 	go test -race -ldflags $(BUILD_LD_FLAGS) $(TEST_PKG) --timeout 90m --count 1 -failfast  $(TEST_ARG)
 
 test-short:
-	go test -race -ldflags $(BUILD_LD_FLAGS) --short --count 1 -timeout 25m -failfast $(strip $(TEST_SHORT_PKGS))
+	go test -race -ldflags $(BUILD_LD_FLAGS) --short --count 1 -timeout 60m -failfast $(strip $(TEST_SHORT_PKGS))
 
 test-cluster: install
 	go test -race -ldflags $(BUILD_LD_FLAGS) --count 1 -timeout 25m -failfast $(shell go list ./tools/cluster/tests/...)

--- a/packages/testutil/peering_net_behaviour_test.go
+++ b/packages/testutil/peering_net_behaviour_test.go
@@ -62,17 +62,17 @@ func TestPeeringNetUnreliable(t *testing.T) {
 	someNode := peeringNode{peeringURL: "src", identity: srcPeerIdentity}
 	behavior := NewPeeringNetUnreliable(50, 50, 50*time.Millisecond, 100*time.Millisecond, testlogger.WithLevel(testlogger.NewLogger(t), log.LevelError, false))
 	behavior.AddLink(inCh, outCh, dstPeerIdentity.GetPublicKey())
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 2000; i++ {
 		inCh <- &peeringMsg{from: someNode.identity.GetPublicKey()}
 	}
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	stopCh <- true
 
 	//
 	// Validate the results (with some tolerance for randomness).
 	{ // 50% of messages dropped + 50% duplicated -> delivered ~75%
-		require.Greater(t, len(durations), 500)
-		require.Less(t, len(durations), 900)
+		require.Greater(t, len(durations), 1000)
+		require.Less(t, len(durations), 1800)
 	}
 	{ // Average should be between the specified boundaries.
 		var avgDuration int64 = 0
@@ -80,8 +80,8 @@ func TestPeeringNetUnreliable(t *testing.T) {
 			avgDuration += d.Milliseconds()
 		}
 		avgDuration /= int64(len(durations))
-		require.Greater(t, avgDuration, int64(50))
-		require.Less(t, avgDuration, int64(120))
+		require.GreaterOrEqual(t, avgDuration, int64(50))
+		require.LessOrEqual(t, avgDuration, int64(150))
 	}
 
 	behavior.Close()

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -1470,7 +1470,7 @@ func TestChangeGasPerToken(t *testing.T) {
 	require.Greater(t, fee2, fee)
 }
 
-func TestGasPriceIgnoredInEstimateGas(t *testing.T) {
+func TestGasPriceIgnoredInEstimateGas(t *testing.T) { //nolint:tparallel
 	t.Parallel()
 	env := InitEVM(t)
 
@@ -1482,8 +1482,7 @@ func TestGasPriceIgnoredInEstimateGas(t *testing.T) {
 		big.NewInt(10),
 		big.NewInt(100),
 	} {
-		t.Run(fmt.Sprintf("%v", gasPrice), func(t *testing.T) { //nolint:gocritic // false positive
-			t.Parallel()
+		t.Run(fmt.Sprintf("%v", gasPrice), func(t *testing.T) { //nolint:gocritic// false positive
 			ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 			storage := env.deployStorageContract(ethKey)
 

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -1483,6 +1483,7 @@ func TestGasPriceIgnoredInEstimateGas(t *testing.T) {
 		big.NewInt(100),
 	} {
 		t.Run(fmt.Sprintf("%v", gasPrice), func(t *testing.T) { //nolint:gocritic // false positive
+			t.Parallel()
 			ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 			storage := env.deployStorageContract(ethKey)
 

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -53,6 +54,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestStorageContract(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.EthereumAccountByIndexWithL2Funds(0)
 	require.EqualValues(t, 1, env.getBlockNumber()) // evm block number is incremented along with ISC block index
@@ -95,6 +97,7 @@ func TestStorageContract(t *testing.T) {
 }
 
 func TestLowLevelCallRevert(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -114,6 +117,7 @@ func TestLowLevelCallRevert(t *testing.T) {
 }
 
 func TestERC20Contract(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -143,6 +147,7 @@ func TestERC20Contract(t *testing.T) {
 }
 
 func TestGetCode(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	erc20 := env.deployERC20Contract(ethKey, "TestCoin", "TEST")
@@ -155,6 +160,7 @@ func TestGetCode(t *testing.T) {
 }
 
 func TestGasCharged(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	storage := env.deployStorageContract(ethKey)
@@ -171,6 +177,7 @@ func TestGasCharged(t *testing.T) {
 }
 
 func TestGasRatio(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	env.Chain.MustDepositBaseTokensToL2(solo.DefaultChainAdminBaseTokens, nil)
 
@@ -204,6 +211,7 @@ func TestGasRatio(t *testing.T) {
 
 // tests that the gas limits are correctly enforced based on the base tokens sent
 func TestGasLimit(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	env.Chain.MustDepositBaseTokensToL2(solo.DefaultChainAdminBaseTokens, nil)
 
@@ -230,6 +238,7 @@ func TestGasLimit(t *testing.T) {
 }
 
 func TestNotEnoughISCGas(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	env.Chain.MustDepositBaseTokensToL2(solo.DefaultChainAdminBaseTokens, nil)
 
@@ -267,6 +276,7 @@ func TestNotEnoughISCGas(t *testing.T) {
 
 // ensure the amount of base tokens sent impacts the amount of gas used
 func TestLoop(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	loop := env.deployLoopContract(ethKey)
@@ -294,6 +304,7 @@ func TestLoop(t *testing.T) {
 }
 
 func TestLoopWithGasLeft(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -316,6 +327,7 @@ func TestLoopWithGasLeft(t *testing.T) {
 }
 
 func TestEstimateGasWithoutFunds(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -333,6 +345,7 @@ func TestEstimateGasWithoutFunds(t *testing.T) {
 }
 
 func TestLoopWithGasLeftEstimateGas(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, ethAddr := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -361,6 +374,7 @@ func TestLoopWithGasLeftEstimateGas(t *testing.T) {
 }
 
 func TestEstimateContractGas(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	env.Chain.MustDepositBaseTokensToL2(solo.DefaultChainAdminBaseTokens, nil)
 
@@ -391,6 +405,7 @@ func TestEstimateContractGas(t *testing.T) {
 }
 
 func TestCallViewGasLimit(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	loop := env.deployLoopContract(ethKey)
@@ -408,6 +423,7 @@ func TestCallViewGasLimit(t *testing.T) {
 }
 
 func TestMagicContract(t *testing.T) {
+	t.Parallel()
 	// deploy the evm contract, which starts an EVM chain and automatically
 	// deploys the isc.sol EVM contract at address 0x10740000...
 	env := InitEVM(t)
@@ -425,6 +441,7 @@ func TestMagicContract(t *testing.T) {
 }
 
 func TestISCChainAdmin(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -438,6 +455,7 @@ func TestISCChainAdmin(t *testing.T) {
 }
 
 func TestISCTimestamp(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -452,6 +470,7 @@ func TestISCTimestamp(t *testing.T) {
 }
 
 func TestISCCallView(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	var ret [][]byte
@@ -464,6 +483,7 @@ func TestISCCallView(t *testing.T) {
 }
 
 func TestISCTriggerEvent(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -481,6 +501,7 @@ func TestISCTriggerEvent(t *testing.T) {
 }
 
 func TestISCTriggerEventThenFail(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -496,6 +517,7 @@ func TestISCTriggerEventThenFail(t *testing.T) {
 }
 
 func TestISCEntropy(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -511,6 +533,7 @@ func TestISCEntropy(t *testing.T) {
 }
 
 func TestISCGetRequestID(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -526,6 +549,7 @@ func TestISCGetRequestID(t *testing.T) {
 }
 
 func TestReceiptOfFailedTxDoesNotContainEvents(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -539,6 +563,7 @@ func TestReceiptOfFailedTxDoesNotContainEvents(t *testing.T) {
 }
 
 func TestISCGetSenderAccount(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -552,6 +577,7 @@ func TestISCGetSenderAccount(t *testing.T) {
 }
 
 func TestSendNonPayableValueTX(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 
 	ethKey, ethAddress := env.Chain.NewEthereumAccountWithL2Funds()
@@ -587,6 +613,7 @@ func TestSendNonPayableValueTX(t *testing.T) {
 }
 
 func TestSendPayableValueTX(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 
 	ethKey, senderEthAddress := env.Chain.NewEthereumAccountWithL2Funds()
@@ -626,6 +653,7 @@ func TestSendPayableValueTX(t *testing.T) {
 }
 
 func TestSendBaseTokens(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 
 	ethKey, ethAddress := env.Chain.EthereumAccountByIndexWithL2Funds(0)
@@ -678,6 +706,7 @@ func TestSendBaseTokens(t *testing.T) {
 }
 
 func TestCannotDepleteAccount(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 
 	ethKey, ethAddress := env.Chain.NewEthereumAccountWithL2Funds()
@@ -717,6 +746,7 @@ func TestCannotDepleteAccount(t *testing.T) {
 }
 
 func TestISCCall(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -731,6 +761,7 @@ func TestISCCall(t *testing.T) {
 }
 
 func TestFibonacciContract(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	fibo := env.deployFibonacciContract(ethKey)
@@ -744,6 +775,7 @@ func TestFibonacciContract(t *testing.T) {
 }
 
 func TestEVMContractOwnsFundsL2Transfer(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -771,6 +803,7 @@ func TestEVMContractOwnsFundsL2Transfer(t *testing.T) {
 }
 
 func TestISCPanic(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -788,6 +821,7 @@ func TestISCPanic(t *testing.T) {
 }
 
 func TestERC20BaseTokens(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, ethAddr := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -893,6 +927,7 @@ func TestERC20BaseTokens(t *testing.T) {
 
 // test withdrawing ALL EVM balance to a L1 address via the magic contract
 func TestEVMWithdrawAll(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, ethAddress := env.Chain.NewEthereumAccountWithL2Funds()
 	_, receiver := env.solo.NewKeyPair()
@@ -953,6 +988,7 @@ func TestEVMWithdrawAll(t *testing.T) {
 }
 
 func TestEVMGasPriceMismatch(t *testing.T) {
+	t.Parallel()
 	for _, v := range []struct {
 		name          string
 		gasPerToken   util.Ratio32
@@ -1047,6 +1083,7 @@ func TestEVMGasPriceMismatch(t *testing.T) {
 		},
 	} {
 		t.Run(v.name, func(t *testing.T) {
+			t.Parallel()
 			env := InitEVM(t)
 			env.Chain.DepositBaseTokensToL2(10*isc.Million, nil)
 			feePolicy := env.Chain.GetGasFeePolicy()
@@ -1093,6 +1130,7 @@ func TestEVMGasPriceMismatch(t *testing.T) {
 }
 
 func TestEVMIntrinsicGas(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	sandbox := env.ISCMagicSandbox(ethKey)
@@ -1105,6 +1143,7 @@ func TestEVMIntrinsicGas(t *testing.T) {
 }
 
 func TestEVMTransferBaseTokens(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, ethAddr := env.Chain.NewEthereumAccountWithL2Funds()
 	_, someEthereumAddr := solo.NewEthereumAccount()
@@ -1132,6 +1171,7 @@ func TestEVMTransferBaseTokens(t *testing.T) {
 }
 
 func TestSolidityTransferBaseTokens(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	_, someEthereumAddr := solo.NewEthereumAccount()
@@ -1195,6 +1235,7 @@ func TestSolidityTransferBaseTokens(t *testing.T) {
 }
 
 func TestSendEntireBalance(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, ethAddr := env.Chain.NewEthereumAccountWithL2Funds()
 	_, someEthereumAddr := solo.NewEthereumAccount()
@@ -1256,6 +1297,7 @@ func TestSendEntireBalance(t *testing.T) {
 }
 
 func TestSolidityRevertMessage(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, ethAddr := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -1286,6 +1328,7 @@ func TestSolidityRevertMessage(t *testing.T) {
 }
 
 func TestCallContractCannotCauseStackOverflow(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -1306,6 +1349,7 @@ func TestCallContractCannotCauseStackOverflow(t *testing.T) {
 }
 
 func TestStaticCall(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -1322,6 +1366,7 @@ func TestStaticCall(t *testing.T) {
 }
 
 func TestSelfDestruct(t *testing.T) {
+	t.Parallel()
 	// NOTE: since EIP-6780 self-destruct was deprecated
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.EthereumAccountByIndexWithL2Funds(0)
@@ -1354,6 +1399,7 @@ func TestSelfDestruct(t *testing.T) {
 }
 
 func TestSelfDestruct6780(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.EthereumAccountByIndexWithL2Funds(0)
 	iscTest := env.deployISCTestContract(ethKey)
@@ -1364,6 +1410,7 @@ func TestSelfDestruct6780(t *testing.T) {
 }
 
 func TestChangeGasLimit(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	env.Chain.MustDepositBaseTokensToL2(solo.DefaultChainAdminBaseTokens, nil)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
@@ -1390,6 +1437,7 @@ func TestChangeGasLimit(t *testing.T) {
 }
 
 func TestChangeGasPerToken(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	env.Chain.MustDepositBaseTokensToL2(solo.DefaultChainAdminBaseTokens, nil)
 
@@ -1423,9 +1471,10 @@ func TestChangeGasPerToken(t *testing.T) {
 }
 
 func TestGasPriceIgnoredInEstimateGas(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 
-	var gasLimit []uint64
+	var gasLimit sync.Map
 
 	for _, gasPrice := range []*big.Int{
 		nil,
@@ -1443,16 +1492,22 @@ func TestGasPriceIgnoredInEstimateGas(t *testing.T) {
 			}}, "store", uint32(3))
 			require.NoError(t, err)
 
-			gasLimit = append(gasLimit, gas)
+			gasLimit.Store(gasPrice, gas)
 		})
 	}
 
-	t.Log("gas limit", gasLimit)
-	require.Len(t, lo.Uniq(gasLimit), 1)
+	var gasLimits []uint64
+	gasLimit.Range(func(key, value any) bool {
+		gasLimits = append(gasLimits, value.(uint64))
+		return true
+	})
+	t.Log("gas limit", gasLimits)
+	require.Len(t, lo.Uniq(gasLimits), 1)
 }
 
 // calling views via eth_call must not cost gas (still has a maximum budget, but simple view calls should pass)
 func TestEVMCallViewGas(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 
 	// issue a view call from an account with no funds
@@ -1466,6 +1521,7 @@ func TestEVMCallViewGas(t *testing.T) {
 }
 
 func TestGasPrice(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	env.Chain.DepositBaseTokensToL2(10*isc.Million, nil)
 
@@ -1505,6 +1561,7 @@ func TestGasPrice(t *testing.T) {
 }
 
 func TestTraceTransaction(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, ethAddr := env.Chain.NewEthereumAccountWithL2Funds()
 
@@ -1540,6 +1597,7 @@ func TestTraceTransaction(t *testing.T) {
 }
 
 func TestCaller(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -1557,6 +1615,7 @@ func TestCaller(t *testing.T) {
 }
 
 func TestCustomError(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -1576,6 +1635,7 @@ func TestCustomError(t *testing.T) {
 }
 
 func TestEmitEventAndRevert(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -1587,6 +1647,7 @@ func TestEmitEventAndRevert(t *testing.T) {
 }
 
 func TestL1DepositEVM(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	// ensure that after a deposit to an EVM account, there is a tx/receipt for it to be auditable on the EVM side
 	wallet, l1Addr := env.solo.NewKeyPairWithFunds()
@@ -1655,6 +1716,7 @@ func TestL1DepositEVM(t *testing.T) {
 }
 
 func TestDecimalsConversion(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -1679,6 +1741,7 @@ func TestDecimalsConversion(t *testing.T) {
 }
 
 func TestPreEIP155Transaction(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 	ethKey, _ := env.Chain.EthereumAccountByIndexWithL2Funds(0)
 
@@ -1697,6 +1760,7 @@ func TestPreEIP155Transaction(t *testing.T) {
 }
 
 func TestEVMEventOnFailedL1Deposit(t *testing.T) {
+	t.Parallel()
 	env := InitEVM(t)
 
 	// set gas policy to a higher price (so that it can fails when charging ISC gas)
@@ -1794,9 +1858,11 @@ func testEVMWithdrawWithFailedTx(t *testing.T, withdrawFirst bool) {
 }
 
 func TestEVM_WithdrawWithFailedTxAfter(t *testing.T) {
+	t.Parallel()
 	testEVMWithdrawWithFailedTx(t, true)
 }
 
 func TestEVM_WithdrawWithFailedTxBefore(t *testing.T) {
+	t.Parallel()
 	testEVMWithdrawWithFailedTx(t, false)
 }

--- a/packages/vm/core/evm/evmtest/setup.go
+++ b/packages/vm/core/evm/evmtest/setup.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
@@ -45,7 +46,11 @@ type ethCallOptions struct {
 	gasPrice *big.Int
 }
 
+var initEVMMutex sync.Mutex
+
 func InitEVM(t testing.TB) *SoloChainEnv {
+	initEVMMutex.Lock()
+	defer initEVMMutex.Unlock()
 	env := solo.New(t, &solo.InitOptions{
 		Debug:             true,
 		PrintStackTrace:   true,


### PR DESCRIPTION
Parallelizes `evmtest` tests, resulting in a 2x speedup and completion in ~15 minutes. 