### PR TITLE
Wip/use temp cli

### DIFF
--- a/tools/cluster/tests/main_test.go
+++ b/tools/cluster/tests/main_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 // TestMain builds the wasp-cli binary once per package and shares the path via waspCliBinPath.
+// It also ensures the temporary build directory is cleaned up after the test run,
+// unless WASP_CLI_KEEP is set (useful for debugging locally or in CI artifacts).
 func TestMain(m *testing.M) {
 	// Allow bypassing the build if CI provides a prebuilt binary
 	if p := os.Getenv("WASP_CLI_BIN"); p != "" {
@@ -60,7 +62,19 @@ func TestMain(m *testing.M) {
 			panic("failed to build wasp-cli: (cd " + buildCmd.Dir + " && " + strings.Join(buildCmd.Args, " ") + ")\n" + out.String())
 		}
 		waspCliBinPath = binPath
+
+		// Run tests, then cleanup temp build dir unless explicitly kept
+		exitCode := m.Run()
+		if keep := os.Getenv("WASP_CLI_KEEP"); keep == "" || keep == "0" || strings.EqualFold(keep, "false") {
+			_ = os.RemoveAll(tmpDir)
+		} else {
+			// Informative log to stderr so it's visible in CI logs
+			_, _ = os.Stderr.WriteString("[wasp-cli tests] Keeping wasp-cli build dir: " + tmpDir + " (WASP_CLI_KEEP=" + keep + ")\n")
+		}
+
+		os.Exit(exitCode)
 	}
 
+	// If we got here, WASP_CLI_BIN was provided; just run tests normally
 	os.Exit(m.Run())
 }

--- a/tools/cluster/tests/main_test.go
+++ b/tools/cluster/tests/main_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestMain builds the wasp-cli binary once per package and shares the path via waspCliBinPath.
+func TestMain(m *testing.M) {
+	// Allow bypassing the build if CI provides a prebuilt binary
+	if p := os.Getenv("WASP_CLI_BIN"); p != "" {
+		waspCliBinPath = p
+	} else {
+		// Build to a temp file once for this package run
+		tmpDir, err := os.MkdirTemp(os.TempDir(), "wasp-cli-bin-*")
+		if err != nil {
+			panic(err)
+		}
+		// Determine repo root based on this source file location
+		_, thisFile, _, _ := runtime.Caller(0)
+		repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "../../.."))
+		binPath := filepath.Join(tmpDir, "wasp-cli")
+
+		// Resolve the 'go' binary from PATH and derive GOROOT via 'go env' to avoid deprecated runtime.GOROOT()
+		goBin, err := exec.LookPath("go")
+		if err != nil {
+			panic("failed to locate 'go' in PATH: " + err.Error())
+		}
+
+		// Query the active toolchain's GOROOT via 'go env'
+		gorootCmd := exec.CommandContext(context.Background(), goBin, "env", "GOROOT")
+		gorootOut := new(bytes.Buffer)
+		gorootCmd.Stdout = gorootOut
+		gorootCmd.Stderr = gorootOut
+		if err := gorootCmd.Run(); err != nil {
+			panic("failed to resolve GOROOT via 'go env': " + gorootOut.String())
+		}
+		goroot := strings.TrimSpace(gorootOut.String())
+
+		buildCmd := exec.CommandContext(context.Background(), goBin, "build", "-o", binPath, "./tools/wasp-cli")
+		buildCmd.Dir = repoRoot
+		// Sanitize environment to align with this toolchain: set GOROOT and clear GOTOOLDIR if present
+		env := os.Environ()
+		// override GOROOT with the value reported by 'go env'
+		env = append(env, "GOROOT="+goroot)
+		// clear GOTOOLDIR to let the tool find the right tools under GOROOT/bin
+		// (cannot remove easily; set to empty to neutralize)
+		env = append(env, "GOTOOLDIR=")
+		buildCmd.Env = env
+		out := new(bytes.Buffer)
+		buildCmd.Stdout = out
+		buildCmd.Stderr = out
+		if err := buildCmd.Run(); err != nil {
+			panic("failed to build wasp-cli: (cd " + buildCmd.Dir + " && " + strings.Join(buildCmd.Args, " ") + ")\n" + out.String())
+		}
+		waspCliBinPath = binPath
+	}
+
+	os.Exit(m.Run())
+}

--- a/tools/cluster/tests/wasp-cli.go
+++ b/tools/cluster/tests/wasp-cli.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -29,7 +31,12 @@ type WaspCLITest struct {
 	Cluster        *cluster.Cluster
 	dir            string
 	WaspCliAddress *cryptolib.Address
+	binPath        string
 }
+
+// waspCliBinPath is set once per package (in TestMain).
+// If empty, newWaspCLITest will build a private binary as a fallback.
+var waspCliBinPath string
 
 func newWaspCLITest(t *testing.T, opt ...waspClusterOpts) *WaspCLITest {
 	clu := newCluster(t, opt...)
@@ -41,6 +48,22 @@ func newWaspCLITest(t *testing.T, opt ...waspClusterOpts) *WaspCLITest {
 		os.RemoveAll(dir)
 	})
 
+	// Prefer the binary built once in TestMain; if not set, build a private one as a fallback
+	binPath := waspCliBinPath
+	if binPath == "" {
+		// Determine repo root based on this source file location
+		_, thisFile, _, _ := runtime.Caller(0)
+		repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "../../.."))
+		binPath = filepath.Join(dir, "wasp-cli")
+		buildCmd := exec.CommandContext(context.Background(), "go", "build", "-o", binPath, "./tools/wasp-cli")
+		buildCmd.Dir = repoRoot
+		buildOut := new(bytes.Buffer)
+		buildCmd.Stdout = buildOut
+		buildCmd.Stderr = buildOut
+		t.Logf("Building wasp-cli (fallback): (cd %s && %s)", buildCmd.Dir, strings.Join(buildCmd.Args, " "))
+		require.NoError(t, buildCmd.Run(), "failed to build wasp-cli: %s", buildOut.String())
+	}
+
 	// creating a config in a temp dir per test. If not provided, wasp-cli will reuse the config from HOME dir, which could mess up other tests or local configuration.
 	err = os.WriteFile(path.Join(dir, "wasp-cli.json"), []byte("{}"), 0o644)
 	require.NoError(t, err)
@@ -49,6 +72,7 @@ func newWaspCLITest(t *testing.T, opt ...waspClusterOpts) *WaspCLITest {
 		T:       t,
 		Cluster: clu,
 		dir:     dir,
+		binPath: binPath,
 	}
 	w.MustRun("wallet", "provider", "unsafe_inmemory_testing_seed")
 	w.MustRun("wallet", "init")
@@ -75,8 +99,10 @@ func (w *WaspCLITest) runCmd(args []string, f func(*exec.Cmd)) ([]string, error)
 	w.T.Helper()
 	// -w: wait for requests
 	// -d: debug output
-	cmd := exec.Command("wasp-cli", append([]string{"-c", w.dir + "/wasp-cli.json", "-w=2m", "-d"}, args...)...) //nolint:gosec
+	cmd := exec.Command(w.binPath, append([]string{"-c", w.dir + "/wasp-cli.json", "-w=2m", "-d"}, args...)...) //nolint:gosec
 	cmd.Dir = w.dir
+	// Ensure cli does not fall back to user's HOME; sandbox into the test temp dir
+	cmd.Env = append(os.Environ(), "HOME="+w.dir)
 
 	stdout := new(bytes.Buffer)
 	cmd.Stdout = stdout


### PR DESCRIPTION
- Build wasp-cli once per package and reuse across the test suite for speed and isolation.
- Clean up the temporary build directory by default; allow keeping it via WASP_CLI_KEEP.