### PR TITLE
Replace sleep calls with require.Eventually

### DIFF
--- a/packages/chain/node_test.go
+++ b/packages/chain/node_test.go
@@ -169,7 +169,7 @@ func testNodeBasic(t *testing.T, n, f int, reliable bool, timeout time.Duration,
 
 	// assert state
 	for i, node := range te.nodes {
-		for {
+		require.Eventually(t, func() bool {
 			latestState, err := node.LatestState(chain.ActiveOrCommittedState)
 			require.NoError(t, err)
 			cnt := inccounter.NewStateAccess(latestState).GetCounter()
@@ -186,26 +186,25 @@ func testNodeBasic(t *testing.T, n, f int, reliable bool, timeout time.Duration,
 					require.NoError(t, err)
 					require.GreaterOrEqual(t, incCount, inccounter.NewStateAccess(st).GetCounter())
 				*/
-				break
+				return true
 			}
-			time.Sleep(100 * time.Millisecond)
 
-			if reliable {
-				continue
+			if !reliable {
+				//
+				// For the unreliable-network tests we have to retry the requests.
+				// That's because the gossip in the mempool is primitive for now.
+				for ii := range incCount {
+					scRequest := isc.NewOffLedgerRequest(
+						te.chainID,
+						inccounter.FuncIncCounter.Message(nil),
+						uint64(ii),
+						20000,
+					).Sign(scClient)
+					te.nodes[0].ReceiveOffLedgerRequest(scRequest, scClient.GetPublicKey())
+				}
 			}
-			//
-			// For the unreliable-network tests we have to retry the requests.
-			// That's because the gossip in the mempool is primitive for now.
-			for ii := range incCount {
-				scRequest := isc.NewOffLedgerRequest(
-					te.chainID,
-					inccounter.FuncIncCounter.Message(nil),
-					uint64(ii),
-					20000,
-				).Sign(scClient)
-				te.nodes[0].ReceiveOffLedgerRequest(scRequest, scClient.GetPublicKey())
-			}
-		}
+			return false
+		}, timeUntilContextDeadline(ctxTimeout), 100*time.Millisecond, "counter did not reach expected value for node %v", i)
 		// Check if LastAnchor() works as expected.
 		awaitPredicate(te, ctxTimeout, "LatestAnchor", func() bool {
 			confirmedAnchor, err := node.LatestAnchor(chain.ConfirmedState)
@@ -254,19 +253,26 @@ func awaitRequestsProcessed(ctx context.Context, te *testEnv, requests []isc.Req
 }
 
 func awaitPredicate(te *testEnv, ctx context.Context, desc string, predicate func() bool) {
-	for {
-		select {
-		case <-ctx.Done():
-			require.FailNowf(te.t, "awaitPredicate failed: %s", desc)
-		default:
-			if predicate() {
-				te.log.LogDebugf("Predicate %v become true.", desc)
-				return
-			}
-			te.log.LogDebugf("Predicate %v still false, will retry.", desc)
-			time.Sleep(100 * time.Millisecond)
+	require.Eventually(te.t, func() bool {
+		if predicate() {
+			te.log.LogDebugf("Predicate %v become true.", desc)
+			return true
 		}
+		te.log.LogDebugf("Predicate %v still false, will retry.", desc)
+		return false
+	}, timeUntilContextDeadline(ctx), 10*time.Millisecond, "awaitPredicate failed: %s", desc)
+}
+
+// timeUntilContextDeadline returns the remaining time until the context deadline,
+// or a default duration if the context has no deadline.
+func timeUntilContextDeadline(ctx context.Context) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		if d := time.Until(deadline); d > 0 {
+			return d
+		}
+		return time.Millisecond
 	}
+	return 2 * time.Second
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/chains/accessmanager/access_manager_test.go
+++ b/packages/chains/accessmanager/access_manager_test.go
@@ -103,27 +103,18 @@ func testBasic(t *testing.T, n int, reliable bool) {
 		am.ChainAccessNodes(chainID, peerPubKeys)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testmisc.GetTimeout(1*time.Minute))
-	defer cancel()
-
 	//
 	// Wait for everyone to get the server nodes.
-	for done := false; !done; {
-		func() {
-			require.NoError(t, ctx.Err(), "timeout: wait for everyone to get the server nodes")
+	require.Eventually(t, func() bool {
+		nodeServersMx.Lock()
+		defer nodeServersMx.Unlock()
 
-			time.Sleep(100 * time.Millisecond)
-			done = true
-			nodeServersMx.Lock()
-			defer nodeServersMx.Unlock()
-
-			for i := range nodeServers {
-				if !util.Same(nodeServers[i], peerPubKeys) {
-					t.Logf("Wait for node %v", i)
-					done = false
-					break
-				}
+		for i := range nodeServers {
+			if !util.Same(nodeServers[i], peerPubKeys) {
+				t.Logf("Wait for node %v", i)
+				return false
 			}
-		}()
-	}
+		}
+		return true
+	}, testmisc.GetTimeout(1*time.Minute), 100*time.Millisecond, "timeout: wait for everyone to get the server nodes")
 }

--- a/packages/peering/lpp/lpp_net_impl_test.go
+++ b/packages/peering/lpp/lpp_net_impl_test.go
@@ -18,9 +18,12 @@ import (
 )
 
 func TestLPPPeeringImpl(t *testing.T) {
-	// This test is prone to cause simultaneous connections, which breaks the quic connections
-	// Therefore, a sleep is introduced to give some time to connect to the nodes properly.
+	// This test is prone to cause simultaneous connections, which breaks the quic connections.
+	// Nodes are created and started with staggered sleeps to prevent simultaneous QUIC connection
+	// attempts. require.Eventually is used for the final connection-liveness check before sending.
 	const sleepTimeToSettleConnection = 750 * time.Millisecond
+	const connectionTimeout = 15 * time.Second
+	const connectionTick = 50 * time.Millisecond
 	var err error
 	log := testlogger.NewLogger(t)
 	defer log.Shutdown()
@@ -38,7 +41,6 @@ func TestLPPPeeringImpl(t *testing.T) {
 	for _, tnm := range tnms {
 		for i := range peeringURLs {
 			_, err = tnm.TrustPeer(keys[i].GetPublicKey().String(), keys[i].GetPublicKey(), peeringURLs[i])
-			time.Sleep(sleepTimeToSettleConnection)
 			require.NoError(t, err)
 		}
 	}
@@ -56,7 +58,6 @@ func TestLPPPeeringImpl(t *testing.T) {
 
 	for i := range nodes {
 		go nodes[i].Run(context.Background())
-
 		time.Sleep(sleepTimeToSettleConnection)
 	}
 
@@ -75,12 +76,15 @@ func TestLPPPeeringImpl(t *testing.T) {
 		doneCh <- true
 	})
 
-	time.Sleep(sleepTimeToSettleConnection)
+	// Wait for node2→node0 connection to be live before sending (replaces the original 750ms sleep).
+	require.Eventually(t, func() bool {
+		p, err := nodes[2].PeerByPubKey(keys[0].GetPublicKey())
+		return err == nil && p.IsAlive()
+	}, connectionTimeout, connectionTick, "node2 did not establish a live connection to node0")
 
 	n0p2.SendMsg(peering.NewPeerMessageData(chain1, receiver, 125, nil))
 	n1p1.SendMsg(peering.NewPeerMessageData(chain1, receiver, 125, nil))
 	n2p0.SendMsg(peering.NewPeerMessageData(chain2, receiver, 125, nil))
 
 	<-doneCh
-	time.Sleep(100 * time.Millisecond)
 }

--- a/packages/testutil/peering_net_behaviour_test.go
+++ b/packages/testutil/peering_net_behaviour_test.go
@@ -4,6 +4,7 @@
 package testutil // not `..._test` because it uses peeringMsg.
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -43,15 +44,19 @@ func TestPeeringNetUnreliable(t *testing.T) {
 	//
 	// Receiver process.
 	stopCh := make(chan bool)
+	doneCh := make(chan []time.Duration, 1)
 	startTime := time.Now()
-	durations := make([]time.Duration, 0)
+	var recvCount atomic.Int64
 	go func() {
+		durations := make([]time.Duration, 0)
 		for {
 			select {
 			case <-stopCh:
+				doneCh <- durations
 				return
 			case <-outCh:
 				durations = append(durations, time.Since(startTime))
+				recvCount.Add(1)
 			}
 		}
 	}()
@@ -65,8 +70,11 @@ func TestPeeringNetUnreliable(t *testing.T) {
 	for i := 0; i < 2000; i++ {
 		inCh <- &peeringMsg{from: someNode.identity.GetPublicKey()}
 	}
-	time.Sleep(1000 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return recvCount.Load() >= 1000
+	}, 5*time.Second, 100*time.Millisecond, "expected at least 1000 messages to be processed")
 	stopCh <- true
+	durations := <-doneCh
 
 	//
 	// Validate the results (with some tolerance for randomness).
@@ -93,15 +101,19 @@ func TestPeeringNetGoodQuality(t *testing.T) {
 	//
 	// Receiver process.
 	stopCh := make(chan bool)
+	doneCh := make(chan []time.Duration, 1)
 	startTime := time.Now()
-	durations := make([]time.Duration, 0)
+	var recvCount atomic.Int64
 	go func() {
+		durations := make([]time.Duration, 0)
 		for {
 			select {
 			case <-stopCh:
+				doneCh <- durations
 				return
 			case <-outCh:
 				durations = append(durations, time.Since(startTime))
+				recvCount.Add(1)
 			}
 		}
 	}()
@@ -115,8 +127,11 @@ func TestPeeringNetGoodQuality(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		inCh <- &peeringMsg{from: someNode.identity.GetPublicKey()}
 	}
-	time.Sleep(500 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return recvCount.Load() >= 1000
+	}, 5*time.Second, 50*time.Millisecond, "expected all 1000 messages to be processed")
 	stopCh <- true
+	durations := <-doneCh
 
 	//
 	// Validate the results (with some tolerance for randomness).

--- a/packages/util/pipe/pipe_test.go
+++ b/packages/util/pipe/pipe_test.go
@@ -1,9 +1,9 @@
 package pipe
 
 import (
+	"runtime"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -241,7 +241,7 @@ func testPipeConcurrentWriteReadLen[E IntConvertible](factory Factory[E], p Pipe
 				length := p.Len()
 				t.Logf("current channel length is %d", length)
 				// no asserts here - the read/write process is asynchronous
-				time.Sleep(10 * time.Millisecond)
+				runtime.Gosched()
 			}
 		}
 	}()


### PR DESCRIPTION
Replace `time.Sleep` calls with `require.Eventually` in multiple test files for deterministic timing validation instead of arbitrary delays 