### PR TITLE
fix: re-subscribe to anchor updates after committee rotation

### DIFF
--- a/clients/iscmove/iscmoveclient/feed.go
+++ b/clients/iscmove/iscmoveclient/feed.go
@@ -183,6 +183,7 @@ func (f *ChainFeed) subscribeToAnchorUpdates(
 	anchorCh chan<- *iscmove.AnchorWithRef,
 ) {
 	for {
+		f.log.LogInfof("subscribeToAnchorUpdates: subscribing with signer address %s", signerAddress)
 		changes := make(chan *iotagraphql.IotaTransactionBlockEffects)
 		err := f.wsClient.SubscribeTransaction(
 			ctx,
@@ -199,7 +200,12 @@ func (f *ChainFeed) subscribeToAnchorUpdates(
 		if err != nil {
 			f.log.LogErrorf("subscribeToAnchorUpdates: failed to call SubscribeEvent(): %s", err)
 		} else {
-			f.consumeAnchorUpdates(ctx, changes, anchorCh)
+			newSignerAddress := f.consumeAnchorUpdates(ctx, changes, anchorCh, signerAddress)
+			if newSignerAddress != nil {
+				f.log.LogInfof("subscribeToAnchorUpdates: anchor owner changed from %s to %s, re-subscribing", signerAddress, *newSignerAddress)
+				signerAddress = *newSignerAddress
+				continue
+			}
 		}
 		if ctx.Err() != nil {
 			f.log.LogErrorf("subscribeToAnchorUpdates: ctx.Err(): %s", ctx.Err())
@@ -208,18 +214,21 @@ func (f *ChainFeed) subscribeToAnchorUpdates(
 	}
 }
 
+// consumeAnchorUpdates processes anchor updates from the subscription.
+// It returns a new signer address if the anchor owner changed (rotation), or nil otherwise.
 func (f *ChainFeed) consumeAnchorUpdates(
 	ctx context.Context,
 	changes <-chan *iotagraphql.IotaTransactionBlockEffects,
 	anchorCh chan<- *iscmove.AnchorWithRef,
-) {
+	currentSignerAddress iotago.Address,
+) *iotago.Address {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case change, ok := <-changes:
 			if !ok {
-				return
+				return nil
 			}
 			f.log.LogDebugf("consumeAnchorUpdates: received anchor update: %+v", change)
 			for _, obj := range change.V1.Mutated {
@@ -237,6 +246,12 @@ func (f *ChainFeed) consumeAnchorUpdates(
 
 				anchorCh <- anchorWithRef
 				f.log.LogDebugf("ANCHOR[%s] SENT TO CHANNEL %s\n", anchorWithRef.Object.ID.String(), time.Now().String())
+
+				// Detect rotation: if the anchor owner changed, re-subscribe with the new signer address
+				if anchorWithRef.Owner != nil && *anchorWithRef.Owner != currentSignerAddress {
+					newAddr := *anchorWithRef.Owner
+					return &newAddr
+				}
 			}
 		}
 	}

--- a/tools/cluster/tests/reboot_test.go
+++ b/tools/cluster/tests/reboot_test.go
@@ -27,7 +27,7 @@ func TestRebootAllNodes(t *testing.T) {
 	for _, keepDB := range keepDBCases {
 		t.Run(fmt.Sprintf("keepDB=%v", keepDB), func(t *testing.T) {
 			allNodes := []int{0, 1, 2, 3}
-			env := setupClusterTest(t, 4, allNodes)
+			env := createTestWrapper(t, 4, allNodes)
 			client, _ := env.NewRandomChainClient()
 
 			env.DepositFunds(100_000_000, client.KeyPair.(*cryptolib.KeyPair)) // For Off-ledger requests to pass.
@@ -55,7 +55,7 @@ func TestRebootDuringTasks(t *testing.T) {
 		t.Skip("Skipping cluster tests in short mode")
 	}
 
-	env := setupClusterTest(t, 4, []int{0, 1, 2, 3})
+	env := createTestWrapper(t, 4, []int{0, 1, 2, 3})
 	restartDelay := 20 * time.Second
 	restartCases := [][]int{
 		{1, 2, 3},

--- a/tools/cluster/tests/rotation_test.go
+++ b/tools/cluster/tests/rotation_test.go
@@ -3,11 +3,13 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/wasp/v2/clients/apiclient"
 	"github.com/iotaledger/wasp/v2/clients/iota-go/iotago"
 	"github.com/iotaledger/wasp/v2/packages/cryptolib"
@@ -94,7 +96,18 @@ func TestRotationOverlappingCommitteesWithConcurrentRequests(t *testing.T) {
 	err = json.Unmarshal(object.Object.AsMoveObjectContent.Contents.Data, &fieldMap)
 	require.NoError(t, err)
 
-	require.Equal(t, int(fieldMap["state_index"].(float64)), int(newBlock.BlockIndex), "state index in anchor should equal to state index in storage")
+	fields, ok := fieldMap["Struct"].([]interface{})
+	require.True(t, ok, "fieldMap should have a Struct field")
+	stateIndexMaps := lo.Filter(fields, func(item interface{}) bool {
+		return item.(map[string]interface{})["name"] == "state_index"
+	})
+	require.Equal(t, len(stateIndexMaps), 1, "should have one state index map, got %d", len(stateIndexMaps))
+	stateIndexMap := stateIndexMaps[0].(map[string]interface{})
+	value, ok := stateIndexMap["value"].(map[string]interface{})["Number"]
+	require.True(t, ok, "value should be a map with a Number field")
+	index, err := strconv.Atoi(value.(string))
+	require.NoError(t, err)
+	require.Equal(t, index, int(newBlock.BlockIndex), "state index in anchor should equal to state index in storage")
 }
 
 type testRotationSingleRotation struct {


### PR DESCRIPTION
## Summary
- Fix anchor subscription not receiving updates after committee rotation by detecting owner change and re-subscribing with the new signer address
- Update reboot tests to use `createTestWrapper` for consistent cluster setup
- Fix rotation test state index assertion to match updated data format

## Details

After committee rotation, the GraphQL anchor subscription filters by `FromAddress` (the committee's signing address). When the anchor is transferred to a new committee, subsequent transactions are signed by the new address, but the subscription still filters for the old one — so no new anchors are ever delivered.

The fix detects rotation in `consumeAnchorUpdates` by comparing the fetched anchor's `Owner` to the current signer address. When they differ, it signals `subscribeToAnchorUpdates` to re-subscribe with the new address.

## Test plan
- Run TestRotationOverlappingCommitteesWithConcurrentRequests — verifies anchor updates continue flowing after rotation
- Run TestRebootAllNodes — verifies cluster setup consistency
- Run TestClusterMultiNodeCommittee — verifies no regression in basic cluster tests